### PR TITLE
Expose raw Activity Picker view

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1205,7 +1205,7 @@ PODS:
     - React-logger (= 0.74.5)
     - React-perflogger (= 0.74.5)
     - React-utils (= 0.74.5)
-  - ReactNativeDeviceActivity (0.0.34):
+  - ReactNativeDeviceActivity (0.0.36):
     - ExpoModulesCore
   - RNVectorIcons (10.2.0):
     - DoubleConversion
@@ -1507,11 +1507,11 @@ SPEC CHECKSUMS:
   React-runtimescheduler: cfbe85c3510c541ec6dc815c7729b41304b67961
   React-utils: f242eb7e7889419d979ca0e1c02ccc0ea6e43b29
   ReactCommon: f7da14a8827b72704169a48c929bcde802698361
-  ReactNativeDeviceActivity: 479e4b08d182e738073be8fa99b393550932362c
+  ReactNativeDeviceActivity: a539ec7e6e198ebe53eb26389d2bbf42b5612376
   RNVectorIcons: 845eda5c7819bd29699cafd0fc98c9d4afe28c96
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   SwiftLint: 92196976e597b9afec5dbe374810103e6c1d9d7c
-  Yoga: 2246eea72aaf1b816a68a35e6e4b74563653ae09
+  Yoga: 950bbfd7e6f04790fdb51149ed51df41f329fcc8
 
 PODFILE CHECKSUM: 5ae09240dec8db7b55ecff135c6659568a0c6d16
 

--- a/example/screens/ShieldTab.tsx
+++ b/example/screens/ShieldTab.tsx
@@ -212,12 +212,6 @@ export function ShieldTab() {
                     backgroundColor: "transparent",
                     pointerEvents: "none",
                   }}
-                  onRefreshAfterCrash={() => {
-                    setShowSelectionView(false);
-                    setTimeout(() => {
-                      setShowSelectionView(true);
-                    }, 0);
-                  }}
                   headerText="a header text!"
                   footerText="a footer text!"
                   onSelectionChange={onSelectionChange}

--- a/example/screens/ShieldTab.tsx
+++ b/example/screens/ShieldTab.tsx
@@ -12,7 +12,7 @@ import {
 } from "react-native";
 import * as ReactNativeDeviceActivity from "react-native-device-activity";
 import { UIBlurEffectStyle } from "react-native-device-activity/ReactNativeDeviceActivity.types";
-import { Switch, useTheme } from "react-native-paper";
+import { Button, Modal, Portal, Switch, useTheme } from "react-native-paper";
 
 export function ShieldTab() {
   const [shieldTitle, setShieldTitle] = React.useState<string>("");
@@ -141,6 +141,7 @@ export function ShieldTab() {
           />
           <Text>Shield active</Text>
         </View>
+
         <View
           style={{
             flexDirection: "row",
@@ -165,15 +166,17 @@ export function ShieldTab() {
           />
           <Text style={{ flex: 1 }}>Block selected apps</Text>
         </View>
-        <View
-          style={{
-            flexDirection: "row",
-            gap: 10,
-            margin: 10,
-            alignItems: "center",
-          }}
-        >
-          {showSelectionView && (
+        <Button onPress={() => setShowSelectionView(true)}>
+          Show selection view
+        </Button>
+        <Portal>
+          <Modal
+            visible={showSelectionView}
+            onDismiss={() => setShowSelectionView(false)}
+            contentContainerStyle={{
+              height: 600,
+            }}
+          >
             <View
               style={{
                 flex: 1,
@@ -188,6 +191,7 @@ export function ShieldTab() {
                   width: "100%",
                   alignItems: "center",
                   justifyContent: "center",
+                  backgroundColor: "white",
                 }}
                 onPress={() => {
                   setShowSelectionView(false);
@@ -199,30 +203,32 @@ export function ShieldTab() {
                 <Text>Swift view crash - tap to reload</Text>
               </Pressable>
 
-              <ReactNativeDeviceActivity.DeviceActivitySelectionView
-                style={{
-                  flex: 1,
-                  height: 600,
-                  width: "100%",
-                  backgroundColor: "transparent",
-                  pointerEvents: "none",
-                }}
-                onRefreshAfterCrash={() => {
-                  setShowSelectionView(false);
-                  setTimeout(() => {
-                    setShowSelectionView(true);
-                  }, 0);
-                }}
-                headerText="a header text!"
-                footerText="a footer text!"
-                onSelectionChange={onSelectionChange}
-                familyActivitySelection={
-                  familyActivitySelectionResult?.familyActivitySelection
-                }
-              />
+              {showSelectionView && (
+                <ReactNativeDeviceActivity.DeviceActivitySelectionView
+                  style={{
+                    flex: 1,
+                    height: 600,
+                    width: "100%",
+                    backgroundColor: "transparent",
+                    pointerEvents: "none",
+                  }}
+                  onRefreshAfterCrash={() => {
+                    setShowSelectionView(false);
+                    setTimeout(() => {
+                      setShowSelectionView(true);
+                    }, 0);
+                  }}
+                  headerText="a header text!"
+                  footerText="a footer text!"
+                  onSelectionChange={onSelectionChange}
+                  familyActivitySelection={
+                    familyActivitySelectionResult?.familyActivitySelection
+                  }
+                />
+              )}
             </View>
-          )}
-        </View>
+          </Modal>
+        </Portal>
         <Text>
           {familyActivitySelectionResult &&
           familyActivitySelectionResult?.categoryCount < 13

--- a/example/screens/ShieldTab.tsx
+++ b/example/screens/ShieldTab.tsx
@@ -42,8 +42,6 @@ export function ShieldTab() {
     }
   }, [familyActivitySelectionResult?.familyActivitySelection]);
 
-  const theme = useTheme();
-
   const onSelectionChange = useCallback(
     (
       event: NativeSyntheticEvent<{
@@ -80,6 +78,8 @@ export function ShieldTab() {
             blue: 0,
           },
           subtitle: "subtitle",
+          primaryButtonLabel: "primaryButtonLabel",
+          secondaryButtonLabel: "secondaryButtonLabel",
           subtitleColor: {
             red: Math.random() * 255,
             green: Math.random() * 255,
@@ -103,19 +103,19 @@ export function ShieldTab() {
         },
         {
           primary: {
-            type: "unblockAll",
-            behavior: "defer",
+            type: "openApp",
+            behavior: "close",
           },
           secondary: {
             type: "dismiss",
-            behavior: "close",
+            behavior: "defer",
           },
         },
       ),
     [shieldTitle],
   );
 
-  const [showSelectionView, setShowSelectionView] = useState(true);
+  const [showSelectionView, setShowSelectionView] = useState(false);
 
   return (
     <SafeAreaView style={{ flex: 1 }}>

--- a/example/screens/ShieldTab.tsx
+++ b/example/screens/ShieldTab.tsx
@@ -113,6 +113,8 @@ export function ShieldTab() {
     [shieldTitle],
   );
 
+  const [showSelectionView, setShowSelectionView] = useState(true);
+
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <ScrollView style={styles.container}>
@@ -169,42 +171,37 @@ export function ShieldTab() {
             alignItems: "center",
           }}
         >
-          <ReactNativeDeviceActivity.DeviceActivitySelectionView
-            style={{
-              width: 100,
-              height: 40,
-              borderRadius: 20,
-              borderWidth: 10,
-              borderColor: theme.colors.primary,
-            }}
-            headerText="a header text!"
-            footerText="a footer text!"
-            onSelectionChange={onSelectionChange}
-            familyActivitySelection={
-              familyActivitySelectionResult?.familyActivitySelection
-            }
-          >
-            <View
-              pointerEvents="none"
+          {showSelectionView && (
+            <ReactNativeDeviceActivity.DeviceActivitySelectionView
               style={{
-                backgroundColor: theme.colors.primary,
                 flex: 1,
-                alignItems: "center",
-                justifyContent: "center",
+                height: 600,
+                borderRadius: 20,
+                width: "100%",
               }}
-            >
-              <Text style={{ color: "white" }}>Select apps</Text>
-            </View>
-          </ReactNativeDeviceActivity.DeviceActivitySelectionView>
-          <Text>
-            {familyActivitySelectionResult &&
-            familyActivitySelectionResult?.categoryCount < 13
-              ? `${familyActivitySelectionResult?.applicationCount} apps, ${familyActivitySelectionResult?.categoryCount} categories, ${familyActivitySelectionResult?.webDomainCount} domains`
-              : familyActivitySelectionResult?.categoryCount
-                ? "All categories selected"
-                : "Nothing selected"}
-          </Text>
+              onRefreshAfterCrash={() => {
+                setShowSelectionView(false);
+                setTimeout(() => {
+                  setShowSelectionView(true);
+                }, 0);
+              }}
+              headerText="a header text!"
+              footerText="a footer text!"
+              onSelectionChange={onSelectionChange}
+              familyActivitySelection={
+                familyActivitySelectionResult?.familyActivitySelection
+              }
+            />
+          )}
         </View>
+        <Text>
+          {familyActivitySelectionResult &&
+          familyActivitySelectionResult?.categoryCount < 13
+            ? `${familyActivitySelectionResult?.applicationCount} apps, ${familyActivitySelectionResult?.categoryCount} categories, ${familyActivitySelectionResult?.webDomainCount} domains`
+            : familyActivitySelectionResult?.categoryCount
+              ? "All categories selected"
+              : "Nothing selected"}
+        </Text>
         <TextInput
           placeholder="Enter shield title"
           onChangeText={(text) => setShieldTitle(text)}

--- a/example/screens/ShieldTab.tsx
+++ b/example/screens/ShieldTab.tsx
@@ -7,6 +7,8 @@ import {
   View,
   SafeAreaView,
   TextInput,
+  TouchableOpacity,
+  Pressable,
 } from "react-native";
 import * as ReactNativeDeviceActivity from "react-native-device-activity";
 import { UIBlurEffectStyle } from "react-native-device-activity/ReactNativeDeviceActivity.types";
@@ -172,26 +174,53 @@ export function ShieldTab() {
           }}
         >
           {showSelectionView && (
-            <ReactNativeDeviceActivity.DeviceActivitySelectionView
+            <View
               style={{
                 flex: 1,
                 height: 600,
-                borderRadius: 20,
-                width: "100%",
               }}
-              onRefreshAfterCrash={() => {
-                setShowSelectionView(false);
-                setTimeout(() => {
-                  setShowSelectionView(true);
-                }, 0);
-              }}
-              headerText="a header text!"
-              footerText="a footer text!"
-              onSelectionChange={onSelectionChange}
-              familyActivitySelection={
-                familyActivitySelectionResult?.familyActivitySelection
-              }
-            />
+            >
+              <Pressable
+                style={{
+                  flex: 1,
+                  position: "absolute",
+                  height: 600,
+                  width: "100%",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+                onPress={() => {
+                  setShowSelectionView(false);
+                  setTimeout(() => {
+                    setShowSelectionView(true);
+                  }, 100);
+                }}
+              >
+                <Text>Swift view crash - tap to reload</Text>
+              </Pressable>
+
+              <ReactNativeDeviceActivity.DeviceActivitySelectionView
+                style={{
+                  flex: 1,
+                  height: 600,
+                  width: "100%",
+                  backgroundColor: "transparent",
+                  pointerEvents: "none",
+                }}
+                onRefreshAfterCrash={() => {
+                  setShowSelectionView(false);
+                  setTimeout(() => {
+                    setShowSelectionView(true);
+                  }, 0);
+                }}
+                headerText="a header text!"
+                footerText="a footer text!"
+                onSelectionChange={onSelectionChange}
+                familyActivitySelection={
+                  familyActivitySelectionResult?.familyActivitySelection
+                }
+              />
+            </View>
           )}
         </View>
         <Text>

--- a/ios/ReactNativeDeviceActivityModule.swift
+++ b/ios/ReactNativeDeviceActivityModule.swift
@@ -551,16 +551,14 @@ public class ReactNativeDeviceActivityModule: Module {
       "onDeviceActivityMonitorEvent",
       // "onManagedStoreWillChange",
       "onDeviceActivityDetected",
-      "onAuthorizationStatusChange",
-      "onRefreshAfterCrash"
+      "onAuthorizationStatusChange"
     )
 
     // Enables the module to be used as a native view. Definition components that are accepted as part of the
     // view definition: Prop, Events.
     View(ReactNativeDeviceActivityView.self) {
       Events(
-        "onSelectionChange",
-        "onRefreshAfterCrash"
+        "onSelectionChange"
       )
       // Defines a setter for the `name` prop.
       Prop("familyActivitySelection") { (view: ReactNativeDeviceActivityView, prop: String) in

--- a/ios/ReactNativeDeviceActivityModule.swift
+++ b/ios/ReactNativeDeviceActivityModule.swift
@@ -551,14 +551,16 @@ public class ReactNativeDeviceActivityModule: Module {
       "onDeviceActivityMonitorEvent",
       // "onManagedStoreWillChange",
       "onDeviceActivityDetected",
-      "onAuthorizationStatusChange"
+      "onAuthorizationStatusChange",
+      "onRefreshAfterCrash"
     )
 
     // Enables the module to be used as a native view. Definition components that are accepted as part of the
     // view definition: Prop, Events.
     View(ReactNativeDeviceActivityView.self) {
       Events(
-        "onSelectionChange"
+        "onSelectionChange",
+        "onRefreshAfterCrash"
       )
       // Defines a setter for the `name` prop.
       Prop("familyActivitySelection") { (view: ReactNativeDeviceActivityView, prop: String) in

--- a/ios/ReactNativeDeviceActivityView.swift
+++ b/ios/ReactNativeDeviceActivityView.swift
@@ -26,6 +26,11 @@ class ReactNativeDeviceActivityView: ExpoView {
     super.init(appContext: appContext)
 
     clipsToBounds = true
+    backgroundColor = .clear
+    isUserInteractionEnabled = false
+
+    contentView.view.backgroundColor = .clear
+    contentView.view.isUserInteractionEnabled = false
 
     self.addSubview(contentView.view)
 

--- a/ios/ReactNativeDeviceActivityView.swift
+++ b/ios/ReactNativeDeviceActivityView.swift
@@ -18,8 +18,7 @@ class ReactNativeDeviceActivityView: ExpoView {
   required init(appContext: AppContext? = nil) {
     contentView = UIHostingController(
       rootView: ScreenTimeSelectAppsContentView(
-        model: model,
-        onRefreshAfterCrash: onRefreshAfterCrash
+        model: model
       )
     )
 
@@ -49,8 +48,6 @@ class ReactNativeDeviceActivityView: ExpoView {
   }
 
   let onSelectionChange = EventDispatcher()
-
-  let onRefreshAfterCrash = EventDispatcher()
 
   var previousSelection: FamilyActivitySelection?
 

--- a/ios/ReactNativeDeviceActivityView.swift
+++ b/ios/ReactNativeDeviceActivityView.swift
@@ -18,7 +18,8 @@ class ReactNativeDeviceActivityView: ExpoView {
   required init(appContext: AppContext? = nil) {
     contentView = UIHostingController(
       rootView: ScreenTimeSelectAppsContentView(
-        model: model
+        model: model,
+        onRefreshAfterCrash: onRefreshAfterCrash
       )
     )
 
@@ -43,6 +44,8 @@ class ReactNativeDeviceActivityView: ExpoView {
   }
 
   let onSelectionChange = EventDispatcher()
+
+  let onRefreshAfterCrash = EventDispatcher()
 
   var previousSelection: FamilyActivitySelection?
 

--- a/ios/ScreenTimeActivityPicker.swift
+++ b/ios/ScreenTimeActivityPicker.swift
@@ -5,10 +5,10 @@
 //  Created by Robert Herber on 2023-07-05.
 //
 
+import ExpoModulesCore
 import FamilyControls
 import Foundation
 import SwiftUI
-import ExpoModulesCore
 
 @available(iOS 15.0, *)
 class ScreenTimeSelectAppsModel: ObservableObject {
@@ -41,11 +41,13 @@ struct Picker: View {
         selection: $model.activitySelection
       )
       .allowsHitTesting(false)
+      .background(Color.clear)
     } else {
       FamilyActivityPicker(
         selection: $model.activitySelection
       )
       .allowsHitTesting(false)
+      .background(Color.clear)
     }
   }
 }
@@ -57,31 +59,12 @@ struct ScreenTimeSelectAppsContentView: View {
 
   var body: some View {
     if #available(iOS 16.0, *) {
-      ZStack {
-        Button(action: {
-          print("Background tapped - reloading picker")
-          // Delegate will handle reload from RN side
-          onRefreshAfterCrash()
-
-        }) {
-          ZStack {
-            Color.red.opacity(0.2)
-            Text("View crashed - tap to reload")
-              .foregroundColor(.white)
-              .font(.headline)
-              .shadow(radius: 2)
-          }
-          .contentShape(Rectangle())
-        }
-        .buttonStyle(PlainButtonStyle())
-        
-        FamilyActivityPicker(
-          headerText: $model.headerText.wrappedValue,
-          footerText: $model.footerText.wrappedValue,
-          selection: $model.activitySelection
-        )
-        .allowsHitTesting(false)
-      }
+      FamilyActivityPicker(
+        headerText: $model.headerText.wrappedValue,
+        footerText: $model.footerText.wrappedValue,
+        selection: $model.activitySelection
+      )
+      .allowsHitTesting(false)
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .edgesIgnoringSafeArea(.all)
     } else {

--- a/ios/ScreenTimeActivityPicker.swift
+++ b/ios/ScreenTimeActivityPicker.swift
@@ -55,7 +55,6 @@ struct Picker: View {
 @available(iOS 15.0, *)
 struct ScreenTimeSelectAppsContentView: View {
   @ObservedObject var model: ScreenTimeSelectAppsModel
-  var onRefreshAfterCrash: EventDispatcher
 
   var body: some View {
     if #available(iOS 16.0, *) {

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -9,6 +9,7 @@ import FamilyControls
 import Foundation
 import ManagedSettings
 import UIKit
+import WebKit
 import os
 
 var appGroup = "group.ActivityMonitor"
@@ -124,19 +125,30 @@ func openUrl(urlString: String) {
     return  // be safe
   }
 
-  /*let context = NSExtensionContext()
-   context.open(url) { success in
+  let context = NSExtensionContext()
+  context.open(url) { _ in
 
-   }*/
+  }
 
-  let application =
-    UIApplication.value(forKeyPath: #keyPath(UIApplication.shared)) as! UIApplication
+ /* let webView = WKWebView()
+  webView.load(URLRequest(url: url))
+*/
+  /*let application =
+    UIApplication.value(forKeyPath: #keyPath(UIApplication.shared)) as! UIApplication*/
 
-  if #available(iOS 10.0, *) {
+  /*if #available(iOS 10.0, *) {
     application.open(url, options: [:], completionHandler: nil)
   } else {
     application.openURL(url)
-  }
+  }*/
+}
+
+let notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
+
+func notifyAppWithName(name: String) {
+  let notificationName = CFNotificationName(name as CFString)
+
+  CFNotificationCenterPostNotification(notificationCenter, notificationName, nil, nil, false)
 }
 
 func sendNotification(contents: [String: Any], placeholders: [String: String?]) {

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -130,7 +130,7 @@ func openUrl(urlString: String) {
 
   }
 
- /* let webView = WKWebView()
+  /* let webView = WKWebView()
   webView.load(URLRequest(url: url))
 */
   /*let application =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.0.36",
+  "version": "0.1.0",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/ReactNativeDeviceActivity.types.ts
+++ b/src/ReactNativeDeviceActivity.types.ts
@@ -136,17 +136,38 @@ export type DeviceActivityEvent = {
   includesPastActivity?: boolean;
 };
 
-export type ShieldActionType = "unblockAll" | "dismiss" | "unblockCurrentApp";
+export type ShieldActionType =
+  | "unblockAll"
+  | "dismiss"
+  | "unblockCurrentApp"
+  | "sendNotification"
+  | "openApp";
 
 export type ShieldAction = {
   type: ShieldActionType;
   delay?: number;
+  payload?: NotificationPayload;
   behavior: "close" | "defer";
 };
 
 export type ShieldActions = {
   primary: ShieldAction;
   secondary?: ShieldAction;
+};
+
+export type NotificationPayload = {
+  title: string;
+  body: string;
+  sound?: "default" | "defaultCritical" | "defaultRingtone";
+  categoryIdentifier?: string;
+  badge?: number;
+  userInfo?: Record<string, any>;
+  interruptionLevel?: "active" | "critical" | "passive";
+  targetContentIdentifier?: string;
+  launchImageName?: string;
+  identifier?: string;
+  threadIdentifier?: string;
+  subtitle?: string;
 };
 
 export type Action =
@@ -175,20 +196,7 @@ export type Action =
     }
   | {
       type: "sendNotification";
-      payload: {
-        title: string;
-        body: string;
-        sound?: "default" | "defaultCritical" | "defaultRingtone";
-        categoryIdentifier?: string;
-        badge?: number;
-        userInfo?: Record<string, any>;
-        interruptionLevel?: "active" | "critical" | "passive";
-        targetContentIdentifier?: string;
-        launchImageName?: string;
-        identifier?: string;
-        threadIdentifier?: string;
-        subtitle?: string;
-      };
+      payload: NotificationPayload;
       sleepBefore?: number;
       sleepAfter?: number;
     }

--- a/src/ReactNativeDeviceActivity.types.ts
+++ b/src/ReactNativeDeviceActivity.types.ts
@@ -31,6 +31,7 @@ export type DeviceActivitySelectionEvent = {
 
 export type DeviceActivitySelectionViewProps = PropsWithChildren<{
   style: StyleProp<ViewStyle>;
+  onRefreshAfterCrash?: () => void;
   onSelectionChange?: (
     selection: NativeSyntheticEvent<DeviceActivitySelectionEvent>,
   ) => void;

--- a/src/ReactNativeDeviceActivity.types.ts
+++ b/src/ReactNativeDeviceActivity.types.ts
@@ -31,7 +31,6 @@ export type DeviceActivitySelectionEvent = {
 
 export type DeviceActivitySelectionViewProps = PropsWithChildren<{
   style: StyleProp<ViewStyle>;
-  onRefreshAfterCrash?: () => void;
   onSelectionChange?: (
     selection: NativeSyntheticEvent<DeviceActivitySelectionEvent>,
   ) => void;

--- a/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -15,15 +15,6 @@ import os
 // Make sure that your class name matches the NSExtensionPrincipalClass in your Info.plist.
 @available(iOS 15.0, *)
 class DeviceActivityMonitorExtension: DeviceActivityMonitor {
-  let notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
-  let store = ManagedSettingsStore()
-
-  func notifyAppWithName(name: String) {
-    let notificationName = CFNotificationName(name as CFString)
-
-    CFNotificationCenterPostNotification(notificationCenter, notificationName, nil, nil, false)
-  }
-
   override func intervalDidStart(for activity: DeviceActivityName) {
     super.intervalDidStart(for: activity)
     logger.log("intervalDidStart")
@@ -33,7 +24,7 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
       callbackName: "intervalDidStart"
     )
 
-    self.notifyAppWithName(name: "intervalDidStart")
+    notifyAppWithName(name: "intervalDidStart")
 
     self.executeActionsForEvent(activityName: activity.rawValue, callbackName: "intervalDidStart")
   }
@@ -49,7 +40,7 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
 
     CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
 
-    self.notifyAppWithName(name: "intervalDidEnd")
+    notifyAppWithName(name: "intervalDidEnd")
 
     self.executeActionsForEvent(activityName: activity.rawValue, callbackName: "intervalDidEnd")
   }
@@ -84,7 +75,7 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
       eventName: event.rawValue
     )
 
-    self.notifyAppWithName(name: "eventDidReachThreshold")
+    notifyAppWithName(name: "eventDidReachThreshold")
 
     self.executeActionsForEvent(
       activityName: activity.rawValue, callbackName: "eventDidReachThreshold",
@@ -100,7 +91,7 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
       callbackName: "intervalWillStartWarning"
     )
 
-    self.notifyAppWithName(name: "intervalWillStartWarning")
+    notifyAppWithName(name: "intervalWillStartWarning")
 
     self.executeActionsForEvent(
       activityName: activity.rawValue, callbackName: "intervalWillStartWarning")
@@ -115,7 +106,7 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
       callbackName: "intervalWillEndWarning"
     )
 
-    self.notifyAppWithName(name: "intervalWillEndWarning")
+    notifyAppWithName(name: "intervalWillEndWarning")
 
     self.executeActionsForEvent(
       activityName: activity.rawValue, callbackName: "intervalWillEndWarning")
@@ -133,7 +124,7 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
       eventName: event.rawValue
     )
 
-    self.notifyAppWithName(name: "eventWillReachThresholdWarning")
+    notifyAppWithName(name: "eventWillReachThresholdWarning")
 
     self.executeActionsForEvent(
       activityName: activity.rawValue, callbackName: "eventWillReachThresholdWarning",

--- a/targets/ShieldAction/ShieldActionExtension.swift
+++ b/targets/ShieldAction/ShieldActionExtension.swift
@@ -20,6 +20,21 @@ func handleAction(
       unblockAllApps()
     }
 
+    if type == "sendNotification" {
+      // todo: replace with general string
+      /*DispatchQueue.main.async(execute: {
+        openUrl(urlString: "device-activity://")
+      })
+
+      notifyAppWithName(name: "fromShieldExtensions")
+
+      sleep(ms: 1)*/
+
+      if let payload = configForSelectedAction["payload"] as? [String: Any] {
+        sendNotification(contents: payload, placeholders: [:])
+      }
+    }
+
     if type == "unblockCurrentApp" {
       let unblockedSelectionStr = userDefaults?.string(forKey: "unblockedSelection")
 


### PR DESCRIPTION
Exposing the raw Activity Picker view, which allows:
- Presenting a fallback view when it crashes.
- Provide this fallback view on the RN side.
- We can also (and should) provide whichever dialog pattern we would like. Previously it was all wrapper in a SwiftUI sheet, for better or worse.
- Should hopefully get rid of white "straps" over the Activity Picker view (caused by safe area handling?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced device activity monitoring and interaction capabilities
	- Added support for sending notifications with detailed payload
	- Improved URL handling and inter-process communication

- **Bug Fixes**
	- Refined screen time activity picker functionality
	- Updated modal and selection view interactions

- **Version Update**
	- Package version bumped from 0.0.36 to 0.1.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->