### PR TITLE
chore(iOS): only copy shared to targets in the package, not to all

### DIFF
--- a/config-plugin/withCopyTargetFolder.js
+++ b/config-plugin/withCopyTargetFolder.js
@@ -26,7 +26,7 @@ const withCopyTargetFolder = (
     recursive: true,
   });
 
-  const nativeTargets = fs.readdirSync(projectTargetFolderPath, {
+  const nativeTargets = fs.readdirSync(packageTargetFolderPath, {
     withFileTypes: false,
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated source directory configuration for native target processing to improve file management and targeting accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->