### PR TITLE
Prevent retriggering of event actions

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ disabled_rules:
   - type_body_length
   - cyclomatic_complexity
   - file_length
+  - function_parameter_count
 
 included:
 - ios

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Example project setup
 
 The example project is linked specifically to simplify development. This means it's not looking exactly like the published package, but for most intents and purposes it should result in the same outcome.
+
 - The config plugin has a `copyToTargetFolder` option that is set to false. This is to prevent the target folder from being copied to the example project and potentially overwriting the original files.
 - The swift files in the targets folder are linked to the root project instead of duplicated. If adding new swift files, try to link them instead of duplicating to keep things clean.
 - The entitlements and info.plist files however duplicated - to not mess with the example project/signing etc.
@@ -8,4 +9,5 @@ The example project is linked specifically to simplify development. This means i
 - In addition the example project contains an XCode test target as well as SwiftLint.
 
 ## Prebuild
-To try out prebuild functionality (i.e. the config plugin) run `npm run prebuild` in the example project (it uses the `INTERNALLY_TEST_PREBUILD` env variable to behave like a published package). This should be used to verify changes are expected, but the result should not in it's full state be commited to the example project, since it will break the DX of the example project as explained above.
+
+To try out prebuild functionality (i.e. the config plugin) run `npm run prebuild` in the example project (it uses the `INTERNALLY_TEST_EXAMPLE_PROJECT` env variable to behave like a published package). This should be used to verify changes are expected, but the result should not in it's full state be commited to the example project, since it will break the DX of the example project as explained above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@ The example project is linked specifically to simplify development. This means i
 
 ## Prebuild
 
-To try out prebuild functionality (i.e. the config plugin) run `npm run prebuild` in the example project (it uses the `INTERNALLY_TEST_EXAMPLE_PROJECT` env variable to behave like a published package). This should be used to verify changes are expected, but the result should not in it's full state be commited to the example project, since it will break the DX of the example project as explained above.
+To try out prebuild functionality (i.e. the config plugin) run `bun run prebuild` in the example project (it uses the `INTERNALLY_TEST_EXAMPLE_PROJECT` and `COPY_TO_TARGET_FOLDER` env variables to behave like a published package). This should be used to verify changes are expected, but the result should not in it's full state be commited to the example project, since it will break the DX of the example project as explained above.

--- a/config-plugin/getAppGroupFromExpoConfig.js
+++ b/config-plugin/getAppGroupFromExpoConfig.js
@@ -9,7 +9,7 @@ const getAppGroupFromExpoConfig = (config) => {
       const [pluginName] = plugin;
       return (
         pluginName === "react-native-device-activity" ||
-        (process.env.INTERNALLY_TEST_PREBUILD &&
+        (process.env.INTERNALLY_TEST_EXAMPLE_PROJECT &&
           pluginName === "../app.plugin.js")
       );
     }

--- a/config-plugin/withCopyTargetFolder.js
+++ b/config-plugin/withCopyTargetFolder.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 
 /** @type {import('@expo/config-plugins').ConfigPlugin<{ appGroup: string; copyToTargetFolder?: boolean }>} */
 const withCopyTargetFolder = (config, { copyToTargetFolder = true }) => {
-  if (!copyToTargetFolder && !process.env.INTERNALLY_TEST_EXAMPLE_PROJECT) {
+  if (!copyToTargetFolder && !process.env.COPY_TO_TARGET_FOLDER) {
     return config;
   }
 

--- a/config-plugin/withCopyTargetFolder.js
+++ b/config-plugin/withCopyTargetFolder.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 
 /** @type {import('@expo/config-plugins').ConfigPlugin<{ appGroup: string; copyToTargetFolder?: boolean }>} */
 const withCopyTargetFolder = (config, { copyToTargetFolder = true }) => {
-  if (!copyToTargetFolder && !process.env.INTERNALLY_TEST_PREBUILD) {
+  if (!copyToTargetFolder && !process.env.INTERNALLY_TEST_EXAMPLE_PROJECT) {
     return config;
   }
 

--- a/example/ios/Tests/SharedTests.swift
+++ b/example/ios/Tests/SharedTests.swift
@@ -95,6 +95,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -105,6 +106,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -133,6 +135,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: 100,
       skipIfLargerEventRecordedWithinMS: nil,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -143,6 +146,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: 10000,
       skipIfLargerEventRecordedWithinMS: nil,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -172,6 +176,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: 999,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -182,6 +187,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: 1000,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -213,6 +219,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: 100,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -223,9 +230,59 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: 10000,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
+    )
+
+    XCTAssertTrue(shouldExecute)
+    XCTAssertFalse(shouldNotExecute)
+  }
+
+  func testSkipIfLargerTriggeredAfterIntervalStarted() {
+    let activityName = "myActivity"
+    let callbackName = "eventDidReachThreshold"
+
+    let key = userDefaultKeyForEvent(
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: "10"
+    )
+
+    let keyForMonitoringStarted = userDefaultKeyForEvent(
+      activityName: activityName,
+      callbackName: "intervalDidStart"
+    )
+
+    let time = Date.now.addingTimeInterval(-1)
+    let intervalStartTime = Date.now.addingTimeInterval(-2)
+
+    userDefaults?.set(time.timeIntervalSince1970 * 1000, forKey: key)
+    userDefaults?.set(intervalStartTime.timeIntervalSince1970 * 1000, forKey: keyForMonitoringStarted)
+
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
+
+    let shouldExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: nil,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: true,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: "15"
+    )
+
+    let shouldNotExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: nil,
+      skipIfLargerEventRecordedSinceStartOfMonitoring: true,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: "5"
     )
 
     XCTAssertTrue(shouldExecute)

--- a/example/ios/Tests/SharedTests.swift
+++ b/example/ios/Tests/SharedTests.swift
@@ -77,8 +77,8 @@ class SharedTests: XCTestCase {
   }
 }
 
-class SharedTests2: XCTestCase {
-  func testGetLastTriggeredTimeFromUserDefaults() {
+class SkipActionTests: XCTestCase {
+  func testShouldSkipIfAlreadyTriggeredAfter() {
     let activityName = "myActivity"
     let callbackName = "eventDidReachThreshold"
     let eventName = "10"
@@ -143,6 +143,86 @@ class SharedTests2: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: 10000,
       skipIfLargerEventRecordedWithinMS: nil,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    XCTAssertTrue(shouldExecute)
+    XCTAssertFalse(shouldNotExecute)
+  }
+
+  func testShouldSkipIfLargerTriggeredAfter() {
+    let activityName = "myActivity"
+    let callbackName = "eventDidReachThreshold"
+    let eventName = "10"
+    let higherThanEventName = "15"
+    let key = userDefaultKeyForEvent(
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: higherThanEventName
+    )
+
+    userDefaults?.set(1000, forKey: key)
+
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
+
+    let shouldNotExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: 999,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: nil,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    let shouldExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: 1000,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: nil,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    XCTAssertFalse(shouldNotExecute)
+    XCTAssertTrue(shouldExecute)
+  }
+
+  func testSkipIfLargerTriggeredWithinMS() {
+    let activityName = "myActivity"
+    let callbackName = "eventDidReachThreshold"
+    let eventName = "10"
+    let higherThanEventName = "15"
+    let key = userDefaultKeyForEvent(
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: higherThanEventName
+    )
+
+    let time = Date.now.addingTimeInterval(-1)
+
+    userDefaults?.set(time.timeIntervalSince1970 * 1000, forKey: key)
+
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
+
+    let shouldExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: 100,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    let shouldNotExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: 10000,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName

--- a/example/ios/Tests/SharedTests.swift
+++ b/example/ios/Tests/SharedTests.swift
@@ -78,6 +78,42 @@ class SharedTests: XCTestCase {
 }
 
 class SkipActionTests: XCTestCase {
+  func testNeverTriggerBefore() {
+    let activityName = "myActivityWithSkipIfAlreadyTriggeredAfter"
+    let callbackName = "eventDidReachThreshold"
+    let eventName = "10"
+
+    let shouldTriggerTime = Date().timeIntervalSince1970 * 1000 - 10000
+    let shouldNotTriggerTime = Date().timeIntervalSince1970 * 1000 + 10000
+
+    let shouldNotExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: shouldNotTriggerTime,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    let shouldExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: shouldTriggerTime,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    XCTAssertFalse(shouldNotExecute)
+    XCTAssertTrue(shouldExecute)
+  }
+
   func testShouldSkipIfAlreadyTriggeredAfter() {
     let activityName = "myActivityWithSkipIfAlreadyTriggeredAfter"
     let callbackName = "eventDidReachThreshold"
@@ -95,6 +131,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
@@ -106,6 +143,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
@@ -135,6 +173,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: 100,
       skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
@@ -146,6 +185,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: 10000,
       skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
@@ -176,6 +216,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: 999,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
@@ -187,6 +228,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: 1000,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
@@ -219,6 +261,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: 100,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
@@ -230,6 +273,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: 10000,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
@@ -269,6 +313,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: true,
       activityName: activityName,
       callbackName: callbackName,
@@ -280,6 +325,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
+      neverTriggerBefore: nil,
       skipIfLargerEventRecordedSinceIntervalStarted: true,
       activityName: activityName,
       callbackName: callbackName,

--- a/example/ios/Tests/SharedTests.swift
+++ b/example/ios/Tests/SharedTests.swift
@@ -76,3 +76,46 @@ class SharedTests: XCTestCase {
     XCTAssertEqual(result["score"] as? String, "{asNumber:missingValue}")
   }
 }
+
+class SharedTests2: XCTestCase {
+  func isHigherEventNumTest() {
+    let isLower = isHigherEvent(eventName: "5", higherThan: "10")
+    let isEqual = isHigherEvent(eventName: "10", higherThan: "10")
+    let isHigher = isHigherEvent(eventName: "15", higherThan: "10")
+
+    XCTAssertTrue(isHigher)
+    XCTAssertFalse(isEqual)
+    XCTAssertFalse(isLower)
+  }
+
+  func isHigherEventStringTest() {
+    let isHigherBecauseString = isHigherEvent(eventName: "prefix_5", higherThan: "prefix_10")
+    let isEqual = isHigherEvent(eventName: "prefix_10", higherThan: "prefix_10")
+    let isHigher = isHigherEvent(eventName: "prefix_15", higherThan: "prefix_10")
+
+    XCTAssertTrue(isHigher)
+    XCTAssertFalse(isEqual)
+    XCTAssertFalse(isHigherBecauseString)
+  }
+
+  func replaceTest() {
+    let five = replace(
+      key: "event_with_prefix_5",
+      prefix: "event_with_prefix_"
+    )
+
+    let empty = replace(
+      key: "event_with_prefix_",
+      prefix: "event_with_prefix_"
+    )
+
+    let nonmatching = replace(
+      key: "dfgsfgsdfgsdfg",
+      prefix: "event_with_prefix_"
+    )
+
+    XCTAssertEqual(five, "5")
+    XCTAssertEqual(empty, "")
+    XCTAssertEqual(nonmatching, "dfgsfgsdfgsdfg")
+  }
+}

--- a/example/ios/Tests/SharedTests.swift
+++ b/example/ios/Tests/SharedTests.swift
@@ -78,7 +78,81 @@ class SharedTests: XCTestCase {
 }
 
 class SharedTests2: XCTestCase {
-  func isHigherEventNumTest() {
+  func testGetLastTriggeredTimeFromUserDefaults() {
+    let activityName = "myActivity"
+    let callbackName = "eventDidReachThreshold"
+    let eventName = "10"
+    let key = userDefaultKeyForEvent(
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    userDefaults?.set(1000, forKey: key)
+
+    let shouldNotExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: 999,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: nil,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    let shouldExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: 1000,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: nil,
+      skipIfLargerEventRecordedWithinMS: nil,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    XCTAssertFalse(shouldNotExecute)
+    XCTAssertTrue(shouldExecute)
+  }
+
+  func testSkipIfAlreadyTriggeredWithinMS() {
+    let activityName = "myActivity"
+    let callbackName = "eventDidReachThreshold"
+    let eventName = "10"
+    let key = userDefaultKeyForEvent(
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    let time = Date.now.addingTimeInterval(-1)
+
+    userDefaults?.set(time.timeIntervalSince1970 * 1000, forKey: key)
+
+    let shouldExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: 100,
+      skipIfLargerEventRecordedWithinMS: nil,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    let shouldNotExecute = shouldExecuteAction(
+      skipIfAlreadyTriggeredAfter: nil,
+      skipIfLargerEventRecordedAfter: nil,
+      skipIfAlreadyTriggeredWithinMS: 10000,
+      skipIfLargerEventRecordedWithinMS: nil,
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    )
+
+    XCTAssertTrue(shouldExecute)
+    XCTAssertFalse(shouldNotExecute)
+  }
+
+  func testIsHigherEventNum() {
     let isLower = isHigherEvent(eventName: "5", higherThan: "10")
     let isEqual = isHigherEvent(eventName: "10", higherThan: "10")
     let isHigher = isHigherEvent(eventName: "15", higherThan: "10")
@@ -88,17 +162,17 @@ class SharedTests2: XCTestCase {
     XCTAssertFalse(isLower)
   }
 
-  func isHigherEventStringTest() {
+  func testIsHigherEventString() {
     let isHigherBecauseString = isHigherEvent(eventName: "prefix_5", higherThan: "prefix_10")
     let isEqual = isHigherEvent(eventName: "prefix_10", higherThan: "prefix_10")
     let isHigher = isHigherEvent(eventName: "prefix_15", higherThan: "prefix_10")
 
     XCTAssertTrue(isHigher)
     XCTAssertFalse(isEqual)
-    XCTAssertFalse(isHigherBecauseString)
+    XCTAssertTrue(isHigherBecauseString)
   }
 
-  func replaceTest() {
+  func testReplaceText() {
     let five = replace(
       key: "event_with_prefix_5",
       prefix: "event_with_prefix_"

--- a/example/ios/Tests/SharedTests.swift
+++ b/example/ios/Tests/SharedTests.swift
@@ -357,17 +357,17 @@ class SkipActionTests: XCTestCase {
   }
 
   func testReplaceText() {
-    let five = replace(
+    let five = removePrefixIfPresent(
       key: "event_with_prefix_5",
       prefix: "event_with_prefix_"
     )
 
-    let empty = replace(
+    let empty = removePrefixIfPresent(
       key: "event_with_prefix_",
       prefix: "event_with_prefix_"
     )
 
-    let nonmatching = replace(
+    let nonmatching = removePrefixIfPresent(
       key: "dfgsfgsdfgsdfg",
       prefix: "event_with_prefix_"
     )

--- a/example/ios/Tests/SharedTests.swift
+++ b/example/ios/Tests/SharedTests.swift
@@ -95,7 +95,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -106,7 +106,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -135,7 +135,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: 100,
       skipIfLargerEventRecordedWithinMS: nil,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -146,7 +146,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: 10000,
       skipIfLargerEventRecordedWithinMS: nil,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -176,7 +176,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: 999,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -187,7 +187,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: 1000,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -219,7 +219,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: 100,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -230,7 +230,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: 10000,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: false,
+      skipIfLargerEventRecordedSinceIntervalStarted: false,
       activityName: activityName,
       callbackName: callbackName,
       eventName: eventName
@@ -259,7 +259,8 @@ class SkipActionTests: XCTestCase {
     let intervalStartTime = Date.now.addingTimeInterval(-2)
 
     userDefaults?.set(time.timeIntervalSince1970 * 1000, forKey: key)
-    userDefaults?.set(intervalStartTime.timeIntervalSince1970 * 1000, forKey: keyForMonitoringStarted)
+    userDefaults?.set(
+      intervalStartTime.timeIntervalSince1970 * 1000, forKey: keyForMonitoringStarted)
 
     CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
 
@@ -268,7 +269,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: true,
+      skipIfLargerEventRecordedSinceIntervalStarted: true,
       activityName: activityName,
       callbackName: callbackName,
       eventName: "15"
@@ -279,7 +280,7 @@ class SkipActionTests: XCTestCase {
       skipIfLargerEventRecordedAfter: nil,
       skipIfAlreadyTriggeredWithinMS: nil,
       skipIfLargerEventRecordedWithinMS: nil,
-      skipIfLargerEventRecordedSinceStartOfMonitoring: true,
+      skipIfLargerEventRecordedSinceIntervalStarted: true,
       activityName: activityName,
       callbackName: callbackName,
       eventName: "5"

--- a/example/ios/Tests/SharedTests.swift
+++ b/example/ios/Tests/SharedTests.swift
@@ -79,7 +79,7 @@ class SharedTests: XCTestCase {
 
 class SkipActionTests: XCTestCase {
   func testShouldSkipIfAlreadyTriggeredAfter() {
-    let activityName = "myActivity"
+    let activityName = "myActivityWithSkipIfAlreadyTriggeredAfter"
     let callbackName = "eventDidReachThreshold"
     let eventName = "10"
     let key = userDefaultKeyForEvent(
@@ -198,7 +198,7 @@ class SkipActionTests: XCTestCase {
   }
 
   func testSkipIfLargerTriggeredWithinMS() {
-    let activityName = "myActivity"
+    let activityName = "myActivitySkipIfLargerEventRecordedWithinMS"
     let callbackName = "eventDidReachThreshold"
     let eventName = "10"
     let higherThanEventName = "15"

--- a/example/package.json
+++ b/example/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.0",
   "main": "expo/AppEntry.js",
   "scripts": {
-    "start": "expo start",
-    "android": "expo run:android",
-    "ios": "expo run:ios",
-    "web": "expo start --web",
+    "start": "INTERNALLY_TEST_EXAMPLE_PROJECT=true expo start",
+    "android": "INTERNALLY_TEST_EXAMPLE_PROJECT=true expo run:android",
+    "ios": "INTERNALLY_TEST_EXAMPLE_PROJECT=true expo run:ios",
+    "web": "INTERNALLY_TEST_EXAMPLE_PROJECT=true expo start --web",
     "typecheck": "tsc --noEmit",
-    "prebuild": "rm -rf targets && INTERNALLY_TEST_PREBUILD=true npx expo prebuild --platform=ios --clean"
+    "prebuild": "rm -rf targets && INTERNALLY_TEST_EXAMPLE_PROJECT=true npx expo prebuild --platform=ios --clean"
   },
   "dependencies": {
     "expo": "~51.0.39",

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
     "ios": "INTERNALLY_TEST_EXAMPLE_PROJECT=true expo run:ios",
     "web": "INTERNALLY_TEST_EXAMPLE_PROJECT=true expo start --web",
     "typecheck": "tsc --noEmit",
-    "prebuild": "rm -rf targets && INTERNALLY_TEST_EXAMPLE_PROJECT=true npx expo prebuild --platform=ios --clean"
+    "prebuild": "rm -rf targets && COPY_TO_TARGET_FOLDER=true INTERNALLY_TEST_EXAMPLE_PROJECT=true npx expo prebuild --platform=ios --clean"
   },
   "dependencies": {
     "expo": "~51.0.39",

--- a/ios/ReactNativeDeviceActivityModule.swift
+++ b/ios/ReactNativeDeviceActivityModule.swift
@@ -439,6 +439,15 @@ public class ReactNativeDeviceActivityModule: Module {
       // center.stopMonitoring()
 
       center = DeviceActivityCenter()
+
+      watchActivitiesHandle?.cancel()
+      watchActivitiesHandle = center.activities.publisher.sink { activity in
+        self.sendEvent(
+          "onDeviceActivityDetected" as String,
+          [
+            "activityName": activity.rawValue
+          ])
+      }
     }
 
     Function("stopMonitoring") { (activityNames: [String]?) in

--- a/ios/ReactNativeDeviceActivityModule.swift
+++ b/ios/ReactNativeDeviceActivityModule.swift
@@ -66,7 +66,8 @@ struct DeviceActivityEventFromJS: ExpoModulesCore.Record {
   var includesPastActivity: Bool?
 }
 
-func convertToSwiftDateComponents(from dateComponentsFromJS: DateComponentsFromJS) -> DateComponents {
+func convertToSwiftDateComponents(from dateComponentsFromJS: DateComponentsFromJS) -> DateComponents
+{
   var swiftDateComponents = DateComponents()
 
   if let era = dateComponentsFromJS.era {
@@ -259,7 +260,6 @@ public class ReactNativeDeviceActivityModule: Module {
     }
 
     Function("getEvents") { (activityName: String?) -> [AnyHashable: Any] in
-
       let dict = userDefaults?.dictionaryRepresentation()
 
       guard let actualDict = dict else {
@@ -318,7 +318,8 @@ public class ReactNativeDeviceActivityModule: Module {
     }
 
     Function("doesSelectionHaveOverlap") { (familyActivitySelections: [String]) in
-      let decodedFamilyActivitySelections: [FamilyActivitySelection] = familyActivitySelections.map { familyActivitySelection in
+      let decodedFamilyActivitySelections: [FamilyActivitySelection] = familyActivitySelections.map
+      { familyActivitySelection in
         let decoder = JSONDecoder()
         let data = Data(base64Encoded: familyActivitySelection)
         do {

--- a/ios/ReactNativeDeviceActivityModule.swift
+++ b/ios/ReactNativeDeviceActivityModule.swift
@@ -66,8 +66,7 @@ struct DeviceActivityEventFromJS: ExpoModulesCore.Record {
   var includesPastActivity: Bool?
 }
 
-func convertToSwiftDateComponents(from dateComponentsFromJS: DateComponentsFromJS) -> DateComponents
-{
+func convertToSwiftDateComponents(from dateComponentsFromJS: DateComponentsFromJS) -> DateComponents {
   var swiftDateComponents = DateComponents()
 
   if let era = dateComponentsFromJS.era {
@@ -318,8 +317,7 @@ public class ReactNativeDeviceActivityModule: Module {
     }
 
     Function("doesSelectionHaveOverlap") { (familyActivitySelections: [String]) in
-      let decodedFamilyActivitySelections: [FamilyActivitySelection] = familyActivitySelections.map
-      { familyActivitySelection in
+      let decodedFamilyActivitySelections: [FamilyActivitySelection] = familyActivitySelections.map { familyActivitySelection in
         let decoder = JSONDecoder()
         let data = Data(base64Encoded: familyActivitySelection)
         do {

--- a/ios/ReactNativeDeviceActivityModule.swift
+++ b/ios/ReactNativeDeviceActivityModule.swift
@@ -523,21 +523,41 @@ public class ReactNativeDeviceActivityModule: Module {
         && areAnyWebDomainCategoriesEqual
     }
 
-    Function("blockApps") { (familyActivitySelectionStr: String?) in
+    Function("blockAppsWithSelectionId") {
+      (familyActivitySelectionId: String, triggeredBy: String?) in
+      let triggeredBy = triggeredBy ?? "blockAppsWithSelectionId called manually"
+
+      let activitySelection = getFamilyActivitySelectionById(id: familyActivitySelectionId)
+
+      blockSelectedApps(
+        blockSelection: activitySelection,
+        unblockedSelection: nil,
+        triggeredBy: triggeredBy,
+        blockedFamilyActivitySelectionId: familyActivitySelectionId
+      )
+    }
+
+    Function("blockApps") { (familyActivitySelectionStr: String?, triggeredBy: String?) in
+      let triggeredBy = triggeredBy ?? "blockApps called manually"
       if let familyActivitySelectionStr {
         let selection = deserializeFamilyActivitySelection(
           familyActivitySelectionStr: familyActivitySelectionStr
         )
 
-        blockSelectedApps(blockSelection: selection, unblockedSelection: nil)
+        blockSelectedApps(
+          blockSelection: selection,
+          unblockedSelection: nil,
+          triggeredBy: triggeredBy,
+          blockedFamilyActivitySelectionId: nil
+        )
       } else {
         // block all apps
-        blockAllApps()
+        blockAllApps(triggeredBy: triggeredBy)
       }
     }
 
-    Function("unblockApps") {
-      unblockAllApps()
+    Function("unblockApps") { (triggeredBy: String?) in
+      unblockAllApps(triggeredBy: triggeredBy ?? "unblockApps called manually")
     }
 
     AsyncFunction("revokeAuthorization") { () async throws in

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -620,11 +620,19 @@ func shouldExecuteAction(
   skipIfLargerEventRecordedAfter: Double?,
   skipIfAlreadyTriggeredWithinMS: Double?,
   skipIfLargerEventRecordedWithinMS: Double?,
+  neverTriggerBefore: Double?,
   skipIfLargerEventRecordedSinceIntervalStarted: Bool?,
   activityName: String,
   callbackName: String,
   eventName: String?
 ) -> Bool {
+  if let neverTriggerBefore = neverTriggerBefore {
+    let now = Date().timeIntervalSince1970 * 1000
+    if now < neverTriggerBefore {
+      return false
+    }
+  }
+
   if let skipIfAlreadyTriggeredAfter = skipIfAlreadyTriggeredAfter {
     if let lastTriggeredAt = getLastTriggeredTimeFromUserDefaults(
       activityName: activityName,

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -620,7 +620,7 @@ func shouldExecuteAction(
   skipIfLargerEventRecordedAfter: Double?,
   skipIfAlreadyTriggeredWithinMS: Double?,
   skipIfLargerEventRecordedWithinMS: Double?,
-  skipIfLargerEventRecordedSinceStartOfMonitoring: Bool?,
+  skipIfLargerEventRecordedSinceIntervalStarted: Bool?,
   activityName: String,
   callbackName: String,
   eventName: String?
@@ -688,7 +688,8 @@ func shouldExecuteAction(
     }
   }
 
-  if let skipIfLargerEventRecordedSinceStartOfMonitoring = skipIfLargerEventRecordedSinceStartOfMonitoring, let eventName = eventName {
+  if let skipIfLargerEventRecordedSinceIntervalStarted =
+    skipIfLargerEventRecordedSinceIntervalStarted, let eventName = eventName {
     if let skipIfLargerEventRecordedAfter = getLastTriggeredTimeFromUserDefaults(
       activityName: activityName,
       callbackName: "intervalDidStart"

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -620,6 +620,7 @@ func shouldExecuteAction(
   skipIfLargerEventRecordedAfter: Double?,
   skipIfAlreadyTriggeredWithinMS: Double?,
   skipIfLargerEventRecordedWithinMS: Double?,
+  skipIfLargerEventRecordedSinceStartOfMonitoring: Bool?,
   activityName: String,
   callbackName: String,
   eventName: String?
@@ -684,6 +685,25 @@ func shouldExecuteAction(
         "skipping executing actions for \(eventName) because a larger event triggered after \(skipIfLargerEventRecordedAfter)"
       )
       return false
+    }
+  }
+
+  if let skipIfLargerEventRecordedSinceStartOfMonitoring = skipIfLargerEventRecordedSinceStartOfMonitoring, let eventName = eventName {
+    if let skipIfLargerEventRecordedAfter = getLastTriggeredTimeFromUserDefaults(
+      activityName: activityName,
+      callbackName: "intervalDidStart"
+    ) {
+      if hasHigherTriggeredEvent(
+        activityName: activityName,
+        callbackName: callbackName,
+        eventName: eventName,
+        afterDate: skipIfLargerEventRecordedAfter
+      ) {
+        logger.log(
+          "skipping executing actions for \(eventName) because a larger event triggered after \(skipIfLargerEventRecordedAfter)"
+        )
+        return false
+      }
     }
   }
 

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -614,7 +614,7 @@ func isHigherEvent(eventName: String, higherThan: String) -> Bool {
   }
 }
 
-func replace(key: String, prefix: String) -> String {
+func removePrefixIfPresent(key: String, prefix: String) -> String {
   if key.hasPrefix(prefix) {
     return String(key.dropFirst(prefix.count))
   }
@@ -640,7 +640,7 @@ func hasHigherTriggeredEvent(
           )
           && triggeredAt > afterDate
           && isHigherEvent(
-            eventName: replace(key: key, prefix: prefix),
+            eventName: removePrefixIfPresent(key: key, prefix: prefix),
             higherThan: eventName
           )
       }

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -562,6 +562,8 @@ func persistToUserDefaults(activityName: String, callbackName: String, eventName
   )
 
   userDefaults?.set(now, forKey: fullEventName)
+
+  CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
 }
 
 func isHigherEvent(eventName: String, higherThan: String) -> Bool {

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -488,37 +488,37 @@ func blockSelectedApps(
   unblockedSelection: FamilyActivitySelection?
 ) {
   store.shield.applications = blockSelection?.applicationTokens.filter({ token in
-    if let match = unblockedSelection?.applicationTokens.first(where: { $0 == token }) {
-      return match == nil
+    if let match = unblockedSelection?.applicationTokens.contains(where: { $0 == token }) {
+      return match
     }
     return true
   })
 
   store.shield.webDomains = blockSelection?.webDomainTokens.filter({ token in
-    if let match = unblockedSelection?.webDomainTokens.first(where: { $0 == token }) {
-      return match == nil
+    if let match = unblockedSelection?.webDomainTokens.contains(where: { $0 == token }) {
+      return match
     }
     return true
   })
 
-  let applications = unblockedSelection?.applicationTokens ?? Set()
-  let webDomains = unblockedSelection?.webDomainTokens ?? Set()
+  let unblockedApplications = unblockedSelection?.applicationTokens ?? Set()
+  let unblockedWebDomains = unblockedSelection?.webDomainTokens ?? Set()
 
   if let blockSelection = blockSelection {
     store.shield.applicationCategories = .specific(
       blockSelection.categoryTokens,
-      except: applications
+      except: unblockedApplications
     )
     store.shield.webDomainCategories = .specific(
       blockSelection.categoryTokens,
-      except: webDomains
+      except: unblockedWebDomains
     )
   } else {
     store.shield.applicationCategories = .all(
-      except: applications
+      except: unblockedApplications
     )
     store.shield.webDomainCategories = .all(
-      except: webDomains
+      except: unblockedWebDomains
     )
   }
 }

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -33,6 +33,7 @@ func updateShield(shieldId: String?, triggeredBy: String?) {
 
     shieldConfiguration["shieldId"] = shieldId
     shieldConfiguration["triggeredBy"] = triggeredBy
+    shieldConfiguration["updatedAt"] = Date.now.ISO8601Format()
 
     // update default shield
     userDefaults?.set(shieldConfiguration, forKey: SHIELD_CONFIGURATION_KEY)
@@ -43,6 +44,7 @@ func updateShield(shieldId: String?, triggeredBy: String?) {
 
     shieldActions["shieldId"] = shieldId
     shieldActions["triggeredBy"] = triggeredBy
+    shieldActions["updatedAt"] = Date.now.ISO8601Format()
 
     userDefaults?.set(shieldActions, forKey: SHIELD_ACTIONS_KEY)
   }

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -25,6 +25,7 @@ let logger = Logger(
 
 var task: URLSessionDataTask?
 
+@available(iOS 15.0, *)
 func updateShield(shieldId: String?, triggeredBy: String?) {
   let shieldId = shieldId ?? "default"
 
@@ -33,7 +34,7 @@ func updateShield(shieldId: String?, triggeredBy: String?) {
 
     shieldConfiguration["shieldId"] = shieldId
     shieldConfiguration["triggeredBy"] = triggeredBy
-    shieldConfiguration["updatedAt"] = Date.now.ISO8601Format()
+    shieldConfiguration["updatedAt"] = Date().ISO8601Format()
 
     // update default shield
     userDefaults?.set(shieldConfiguration, forKey: SHIELD_CONFIGURATION_KEY)
@@ -44,7 +45,7 @@ func updateShield(shieldId: String?, triggeredBy: String?) {
 
     shieldActions["shieldId"] = shieldId
     shieldActions["triggeredBy"] = triggeredBy
-    shieldActions["updatedAt"] = Date.now.ISO8601Format()
+    shieldActions["updatedAt"] = Date().ISO8601Format()
 
     userDefaults?.set(shieldActions, forKey: SHIELD_ACTIONS_KEY)
   }

--- a/ios/Shared.swift
+++ b/ios/Shared.swift
@@ -503,14 +503,14 @@ func blockSelectedApps(
 ) {
   store.shield.applications = blockSelection?.applicationTokens.filter({ token in
     if let match = unblockedSelection?.applicationTokens.contains(where: { $0 == token }) {
-      return match
+      return !match
     }
     return true
   })
 
   store.shield.webDomains = blockSelection?.webDomainTokens.filter({ token in
     if let match = unblockedSelection?.webDomainTokens.contains(where: { $0 == token }) {
-      return match
+      return !match
     }
     return true
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-activity",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Provides access to Apples DeviceActivity API",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/ReactNativeDeviceActivity.types.ts
+++ b/src/ReactNativeDeviceActivity.types.ts
@@ -180,7 +180,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
+      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
     }
   | {
       type: "unblockAllApps";
@@ -190,7 +190,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
+      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
     }
   | {
       type: "resetUnblockedSelection";
@@ -200,7 +200,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
+      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
     }
   | {
       type: "blockAllApps";
@@ -211,7 +211,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
+      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
     }
   | {
       type: "sendNotification";
@@ -222,7 +222,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
+      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
     }
   | {
       type: "openApp";
@@ -232,7 +232,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
+      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
     }
   | {
       type: "sendHttpRequest";
@@ -248,7 +248,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
+      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
     };
 
 export type DeviceActivityEventRaw = Omit<

--- a/src/ReactNativeDeviceActivity.types.ts
+++ b/src/ReactNativeDeviceActivity.types.ts
@@ -247,8 +247,15 @@ export type ReactNativeDeviceActivityNativeModule = {
     forIndividualOrChild: "individual" | "child",
   ) => PromiseLike<void> | void;
   revokeAuthorization: () => PromiseLike<void> | void;
-  blockApps: (familyActivitySelectionStr?: string) => PromiseLike<void> | void;
-  unblockApps: () => PromiseLike<void> | void;
+  blockApps: (
+    familyActivitySelectionStr?: string,
+    triggeredBy?: string,
+  ) => void;
+  blockAppsWithSelectionId: (
+    familyActivitySelectionId: string,
+    triggeredBy?: string,
+  ) => void;
+  unblockApps: (triggeredBy?: string) => void;
   isShieldActive: () => boolean;
   isShieldActiveWithSelection: (familyActivitySelectionStr: string) => boolean;
   doesSelectionHaveOverlap: (

--- a/src/ReactNativeDeviceActivity.types.ts
+++ b/src/ReactNativeDeviceActivity.types.ts
@@ -169,72 +169,41 @@ export type NotificationPayload = {
   subtitle?: string;
 };
 
+type CommonTypeParams = {
+  sleepBefore?: number;
+  sleepAfter?: number;
+  skipIfAlreadyTriggeredAfter?: Date;
+  skipIfLargerEventRecordedAfter?: Date;
+  skipIfAlreadyTriggeredWithinMS?: number;
+  skipIfLargerEventRecordedWithinMS?: number;
+  skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
+  neverTriggerBefore?: Date;
+};
+
 export type Action =
-  | {
+  | ({
       type: "blockSelection";
       familyActivitySelectionId: string;
       shieldId?: string;
-      sleepBefore?: number;
-      sleepAfter?: number;
-      skipIfAlreadyTriggeredAfter?: Date;
-      skipIfLargerEventRecordedAfter?: Date;
-      skipIfAlreadyTriggeredWithinMS?: number;
-      skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
-    }
-  | {
+    } & CommonTypeParams)
+  | ({
       type: "unblockAllApps";
-      sleepBefore?: number;
-      sleepAfter?: number;
-      skipIfAlreadyTriggeredAfter?: Date;
-      skipIfLargerEventRecordedAfter?: Date;
-      skipIfAlreadyTriggeredWithinMS?: number;
-      skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
-    }
-  | {
+    } & CommonTypeParams)
+  | ({
       type: "resetUnblockedSelection";
-      sleepBefore?: number;
-      sleepAfter?: number;
-      skipIfAlreadyTriggeredAfter?: Date;
-      skipIfLargerEventRecordedAfter?: Date;
-      skipIfAlreadyTriggeredWithinMS?: number;
-      skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
-    }
-  | {
+    } & CommonTypeParams)
+  | ({
       type: "blockAllApps";
       shieldId?: string;
-      sleepBefore?: number;
-      sleepAfter?: number;
-      skipIfAlreadyTriggeredAfter?: Date;
-      skipIfLargerEventRecordedAfter?: Date;
-      skipIfAlreadyTriggeredWithinMS?: number;
-      skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
-    }
-  | {
+    } & CommonTypeParams)
+  | ({
       type: "sendNotification";
       payload: NotificationPayload;
-      sleepBefore?: number;
-      sleepAfter?: number;
-      skipIfAlreadyTriggeredAfter?: Date;
-      skipIfLargerEventRecordedAfter?: Date;
-      skipIfAlreadyTriggeredWithinMS?: number;
-      skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
-    }
-  | {
+    } & CommonTypeParams)
+  | ({
       type: "openApp";
-      sleepBefore?: number;
-      sleepAfter?: number;
-      skipIfAlreadyTriggeredAfter?: Date;
-      skipIfLargerEventRecordedAfter?: Date;
-      skipIfAlreadyTriggeredWithinMS?: number;
-      skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
-    }
-  | {
+    } & CommonTypeParams)
+  | ({
       type: "sendHttpRequest";
       url: string;
       options?: {
@@ -242,14 +211,7 @@ export type Action =
         body?: Record<string, any>;
         headers?: Record<string, string>;
       };
-      sleepBefore?: number;
-      sleepAfter?: number;
-      skipIfAlreadyTriggeredAfter?: Date;
-      skipIfLargerEventRecordedAfter?: Date;
-      skipIfAlreadyTriggeredWithinMS?: number;
-      skipIfLargerEventRecordedWithinMS?: number;
-      skipIfLargerEventRecordedSinceIntervalStarted?: boolean;
-    };
+    } & CommonTypeParams);
 
 export type DeviceActivityEventRaw = Omit<
   DeviceActivityEvent,

--- a/src/ReactNativeDeviceActivity.types.ts
+++ b/src/ReactNativeDeviceActivity.types.ts
@@ -180,6 +180,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
+      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
     }
   | {
       type: "unblockAllApps";
@@ -189,6 +190,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
+      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
     }
   | {
       type: "resetUnblockedSelection";
@@ -198,6 +200,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
+      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
     }
   | {
       type: "blockAllApps";
@@ -208,6 +211,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
+      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
     }
   | {
       type: "sendNotification";
@@ -218,6 +222,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
+      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
     }
   | {
       type: "openApp";
@@ -227,6 +232,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
+      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
     }
   | {
       type: "sendHttpRequest";
@@ -242,6 +248,7 @@ export type Action =
       skipIfLargerEventRecordedAfter?: Date;
       skipIfAlreadyTriggeredWithinMS?: number;
       skipIfLargerEventRecordedWithinMS?: number;
+      skipIfLargerEventRecordedSinceMonitoringStarted?: boolean;
     };
 
 export type DeviceActivityEventRaw = Omit<

--- a/src/ReactNativeDeviceActivity.types.ts
+++ b/src/ReactNativeDeviceActivity.types.ts
@@ -176,33 +176,57 @@ export type Action =
       shieldId?: string;
       sleepBefore?: number;
       sleepAfter?: number;
+      skipIfAlreadyTriggeredAfter?: Date;
+      skipIfLargerEventRecordedAfter?: Date;
+      skipIfAlreadyTriggeredWithinMS?: number;
+      skipIfLargerEventRecordedWithinMS?: number;
     }
   | {
       type: "unblockAllApps";
       sleepBefore?: number;
       sleepAfter?: number;
+      skipIfAlreadyTriggeredAfter?: Date;
+      skipIfLargerEventRecordedAfter?: Date;
+      skipIfAlreadyTriggeredWithinMS?: number;
+      skipIfLargerEventRecordedWithinMS?: number;
     }
   | {
       type: "resetUnblockedSelection";
       sleepBefore?: number;
       sleepAfter?: number;
+      skipIfAlreadyTriggeredAfter?: Date;
+      skipIfLargerEventRecordedAfter?: Date;
+      skipIfAlreadyTriggeredWithinMS?: number;
+      skipIfLargerEventRecordedWithinMS?: number;
     }
   | {
       type: "blockAllApps";
       shieldId?: string;
       sleepBefore?: number;
       sleepAfter?: number;
+      skipIfAlreadyTriggeredAfter?: Date;
+      skipIfLargerEventRecordedAfter?: Date;
+      skipIfAlreadyTriggeredWithinMS?: number;
+      skipIfLargerEventRecordedWithinMS?: number;
     }
   | {
       type: "sendNotification";
       payload: NotificationPayload;
       sleepBefore?: number;
       sleepAfter?: number;
+      skipIfAlreadyTriggeredAfter?: Date;
+      skipIfLargerEventRecordedAfter?: Date;
+      skipIfAlreadyTriggeredWithinMS?: number;
+      skipIfLargerEventRecordedWithinMS?: number;
     }
   | {
       type: "openApp";
       sleepBefore?: number;
       sleepAfter?: number;
+      skipIfAlreadyTriggeredAfter?: Date;
+      skipIfLargerEventRecordedAfter?: Date;
+      skipIfAlreadyTriggeredWithinMS?: number;
+      skipIfLargerEventRecordedWithinMS?: number;
     }
   | {
       type: "sendHttpRequest";
@@ -214,6 +238,10 @@ export type Action =
       };
       sleepBefore?: number;
       sleepAfter?: number;
+      skipIfAlreadyTriggeredAfter?: Date;
+      skipIfLargerEventRecordedAfter?: Date;
+      skipIfAlreadyTriggeredWithinMS?: number;
+      skipIfLargerEventRecordedWithinMS?: number;
     };
 
 export type DeviceActivityEventRaw = Omit<

--- a/src/ReactNativeDeviceActivityModule.ts
+++ b/src/ReactNativeDeviceActivityModule.ts
@@ -28,6 +28,7 @@ const mockModule:
   | null = {
   isAvailable: () => false,
   requestAuthorization: warnFn,
+  blockAppsWithSelectionId: warnFn,
   userDefaultsAll: warnFn,
   userDefaultsGet: warnFn,
   userDefaultsRemove: warnFn,

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,9 @@ export const configureActions = ({
       skipIfAlreadyTriggeredAfter: action.skipIfAlreadyTriggeredAfter
         ? action.skipIfAlreadyTriggeredAfter.getTime()
         : undefined,
+      neverTriggerBefore: action.neverTriggerBefore
+        ? action.neverTriggerBefore.getTime()
+        : undefined,
     })),
   );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -393,10 +393,12 @@ export function updateShield(
   userDefaultsSet(SHIELD_CONFIGURATION_KEY, {
     ...shieldConfiguration,
     triggeredBy,
+    updatedAt: new Date().toISOString(),
   });
   userDefaultsSet(SHIELD_ACTIONS_KEY, {
     ...shieldActions,
     triggeredBy,
+    updatedAt: new Date().toISOString(),
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,10 @@ export async function startMonitoring(
   );
 }
 
+export const reloadDeviceActivityCenter = () => {
+  return ReactNativeDeviceActivityModule?.reloadDeviceActivityCenter();
+};
+
 export const configureActions = ({
   activityName,
   callbackName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,18 @@ export const configureActions = ({
     ? `actions_for_${activityName}_${callbackName}_${eventName}`
     : `actions_for_${activityName}_${callbackName}`;
 
-  userDefaultsSet(key, actions);
+  userDefaultsSet(
+    key,
+    actions.map((action) => ({
+      ...action,
+      skipIfLargerEventRecordedAfter: action.skipIfLargerEventRecordedAfter
+        ? action.skipIfLargerEventRecordedAfter.getTime()
+        : undefined,
+      skipIfAlreadyTriggeredAfter: action.skipIfAlreadyTriggeredAfter
+        ? action.skipIfAlreadyTriggeredAfter.getTime()
+        : undefined,
+    })),
+  );
 };
 
 export const cleanUpAfterActivity = (activityName: string) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,12 +382,22 @@ export function onDeviceActivityMonitorEvent(
   );
 }
 
+export const SHIELD_ACTIONS_KEY = "shieldActions";
+export const SHIELD_CONFIGURATION_KEY = "shieldConfiguration";
+
 export function updateShield(
   shieldConfiguration: ShieldConfiguration,
   shieldActions: ShieldActions,
+  triggeredBy = "updateShieldCalledManually",
 ) {
-  userDefaultsSet(`shieldConfiguration`, shieldConfiguration);
-  userDefaultsSet(`shieldActions`, shieldActions);
+  userDefaultsSet(SHIELD_CONFIGURATION_KEY, {
+    ...shieldConfiguration,
+    triggeredBy,
+  });
+  userDefaultsSet(SHIELD_ACTIONS_KEY, {
+    ...shieldActions,
+    triggeredBy,
+  });
 }
 
 export function useShieldWithId(shieldId: string = "default") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,14 +295,28 @@ export function isShieldActiveWithSelection(
   );
 }
 
-export function blockApps(
-  familyActivitySelectionStr?: string,
-): PromiseLike<void> | void {
-  return ReactNativeDeviceActivityModule?.blockApps(familyActivitySelectionStr);
+export function blockAppsWithSelectionId(
+  familyActivitySelectionId: string,
+  triggeredBy?: string,
+): void {
+  return ReactNativeDeviceActivityModule?.blockAppsWithSelectionId(
+    familyActivitySelectionId,
+    triggeredBy,
+  );
 }
 
-export function unblockApps(): PromiseLike<void> | void {
-  return ReactNativeDeviceActivityModule?.unblockApps();
+export function blockApps(
+  familyActivitySelectionStr?: string,
+  triggeredBy?: string,
+): void {
+  return ReactNativeDeviceActivityModule?.blockApps(
+    familyActivitySelectionStr,
+    triggeredBy,
+  );
+}
+
+export function unblockApps(triggeredBy?: string): void {
+  return ReactNativeDeviceActivityModule?.unblockApps(triggeredBy);
 }
 
 export function getAuthorizationStatus(): AuthorizationStatusType {

--- a/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -77,12 +77,15 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
           let skipIfAlreadyTriggeredWithinMS = action["skipIfAlreadyTriggeredWithinMS"] as? Double
           let skipIfLargerEventRecordedWithinMS =
             action["skipIfLargerEventRecordedWithinMS"] as? Double
+          let skipIfLargerEventRecordedSinceStartOfMonitoring =
+          action["skipIfLargerEventRecordedSinceStartOfMonitoring"] as? Bool
 
           if shouldExecuteAction(
             skipIfAlreadyTriggeredAfter: skipIfAlreadyTriggeredAfter,
             skipIfLargerEventRecordedAfter: skipIfLargerEventRecordedAfter,
             skipIfAlreadyTriggeredWithinMS: skipIfAlreadyTriggeredWithinMS,
             skipIfLargerEventRecordedWithinMS: skipIfLargerEventRecordedWithinMS,
+            skipIfLargerEventRecordedSinceStartOfMonitoring: skipIfLargerEventRecordedSinceStartOfMonitoring,
             activityName: activityName,
             callbackName: callbackName,
             eventName: eventName

--- a/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -11,8 +11,6 @@ import Foundation
 import ManagedSettings
 import os
 
-
-
 // Optionally override any of the functions below.
 // Make sure that your class name matches the NSExtensionPrincipalClass in your Info.plist.
 @available(iOS 15.0, *)

--- a/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -93,7 +93,11 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
             callbackName: callbackName,
             eventName: eventName
           ) {
-            executeAction(action: action, placeholders: placeholders)
+            executeAction(
+              action: action,
+              placeholders: placeholders,
+              eventKey: key
+            )
           }
         }
       }

--- a/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -11,68 +11,7 @@ import Foundation
 import ManagedSettings
 import os
 
-func shouldExecuteAction(
-  skipIfAlreadyTriggeredAfter: Double?,
-  skipIfLargerEventRecordedAfter: Double?,
-  skipIfAlreadyTriggeredWithinMS: Double?,
-  skipIfLargerEventRecordedWithinMS: Double?,
-  activityName: String,
-  callbackName: String,
-  eventName: String? = nil
-) -> Bool {
-  if let skipIfAlreadyTriggeredAfter = skipIfAlreadyTriggeredAfter {
-    if let lastTriggeredAt = getLastTriggeredTimeFromUserDefaults(
-      activityName: activityName,
-      callbackName: callbackName,
-      eventName: eventName
-    ) {
-      if lastTriggeredAt > skipIfAlreadyTriggeredAfter {
-        return false
-      }
-    }
-  }
 
-  if let skipIfLargerEventRecordedAfter = skipIfLargerEventRecordedAfter {
-    if hasHigherTriggeredEvent(
-      activityName: activityName,
-      callbackName: callbackName,
-      eventName: eventName,
-      afterDate: skipIfLargerEventRecordedAfter
-    ) {
-      return false
-    }
-  }
-
-  if let skipIfAlreadyTriggeredWithinMS = skipIfAlreadyTriggeredWithinMS {
-    if let lastTriggeredAt = getLastTriggeredTimeFromUserDefaults(
-      activityName: activityName,
-      callbackName: callbackName,
-      eventName: eventName
-    ) {
-      let skipIfAlreadyTriggeredAfter =
-        Date.now.addingTimeInterval(
-          -skipIfAlreadyTriggeredWithinMS
-        ).timeIntervalSince1970 * 1000
-      if lastTriggeredAt > skipIfAlreadyTriggeredAfter {
-        return false
-      }
-    }
-  }
-
-  if let skipIfLargerEventRecordedWithinMS = skipIfLargerEventRecordedWithinMS {
-    if hasHigherTriggeredEvent(
-      activityName: activityName,
-      callbackName: callbackName,
-      eventName: eventName,
-      afterDate: Date.now
-        .addingTimeInterval(-skipIfLargerEventRecordedWithinMS).timeIntervalSince1970 * 1000
-    ) {
-      return false
-    }
-  }
-
-  return true
-}
 
 // Optionally override any of the functions below.
 // Make sure that your class name matches the NSExtensionPrincipalClass in your Info.plist.

--- a/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -111,8 +111,6 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
       callbackName: "intervalDidEnd"
     )
 
-    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
-
     notifyAppWithName(name: "intervalDidEnd")
   }
 
@@ -131,6 +129,8 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
       "callbackName": callbackName,
       "eventName": eventName
     ]
+
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
 
     if let actions = userDefaults?.array(forKey: key) {
       actions.forEach { actionRaw in
@@ -152,7 +152,6 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
           ) {
             executeAction(action: action, placeholders: placeholders)
           }
-
         }
       }
     }

--- a/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -77,15 +77,16 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
           let skipIfAlreadyTriggeredWithinMS = action["skipIfAlreadyTriggeredWithinMS"] as? Double
           let skipIfLargerEventRecordedWithinMS =
             action["skipIfLargerEventRecordedWithinMS"] as? Double
-          let skipIfLargerEventRecordedSinceStartOfMonitoring =
-          action["skipIfLargerEventRecordedSinceStartOfMonitoring"] as? Bool
+          let skipIfLargerEventRecordedSinceIntervalStarted =
+            action["skipIfLargerEventRecordedSinceIntervalStarted"] as? Bool
 
           if shouldExecuteAction(
             skipIfAlreadyTriggeredAfter: skipIfAlreadyTriggeredAfter,
             skipIfLargerEventRecordedAfter: skipIfLargerEventRecordedAfter,
             skipIfAlreadyTriggeredWithinMS: skipIfAlreadyTriggeredWithinMS,
             skipIfLargerEventRecordedWithinMS: skipIfLargerEventRecordedWithinMS,
-            skipIfLargerEventRecordedSinceStartOfMonitoring: skipIfLargerEventRecordedSinceStartOfMonitoring,
+            skipIfLargerEventRecordedSinceIntervalStarted:
+              skipIfLargerEventRecordedSinceIntervalStarted,
             activityName: activityName,
             callbackName: callbackName,
             eventName: eventName

--- a/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -79,12 +79,14 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
             action["skipIfLargerEventRecordedWithinMS"] as? Double
           let skipIfLargerEventRecordedSinceIntervalStarted =
             action["skipIfLargerEventRecordedSinceIntervalStarted"] as? Bool
+          let neverTriggerBefore = action["neverTriggerBefore"] as? Double
 
           if shouldExecuteAction(
             skipIfAlreadyTriggeredAfter: skipIfAlreadyTriggeredAfter,
             skipIfLargerEventRecordedAfter: skipIfLargerEventRecordedAfter,
             skipIfAlreadyTriggeredWithinMS: skipIfAlreadyTriggeredWithinMS,
             skipIfLargerEventRecordedWithinMS: skipIfLargerEventRecordedWithinMS,
+            neverTriggerBefore: neverTriggerBefore,
             skipIfLargerEventRecordedSinceIntervalStarted:
               skipIfLargerEventRecordedSinceIntervalStarted,
             activityName: activityName,

--- a/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/targets/ActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -11,6 +11,69 @@ import Foundation
 import ManagedSettings
 import os
 
+func shouldExecuteAction(
+  skipIfAlreadyTriggeredAfter: Double?,
+  skipIfLargerEventRecordedAfter: Double?,
+  skipIfAlreadyTriggeredWithinMS: Double?,
+  skipIfLargerEventRecordedWithinMS: Double?,
+  activityName: String,
+  callbackName: String,
+  eventName: String? = nil
+) -> Bool {
+  if let skipIfAlreadyTriggeredAfter = skipIfAlreadyTriggeredAfter {
+    if let lastTriggeredAt = getLastTriggeredTimeFromUserDefaults(
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    ) {
+      if lastTriggeredAt > skipIfAlreadyTriggeredAfter {
+        return false
+      }
+    }
+  }
+
+  if let skipIfLargerEventRecordedAfter = skipIfLargerEventRecordedAfter {
+    if hasHigherTriggeredEvent(
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName,
+      afterDate: skipIfLargerEventRecordedAfter
+    ) {
+      return false
+    }
+  }
+
+  if let skipIfAlreadyTriggeredWithinMS = skipIfAlreadyTriggeredWithinMS {
+    if let lastTriggeredAt = getLastTriggeredTimeFromUserDefaults(
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName
+    ) {
+      let skipIfAlreadyTriggeredAfter =
+        Date.now.addingTimeInterval(
+          -skipIfAlreadyTriggeredWithinMS
+        ).timeIntervalSince1970 * 1000
+      if lastTriggeredAt > skipIfAlreadyTriggeredAfter {
+        return false
+      }
+    }
+  }
+
+  if let skipIfLargerEventRecordedWithinMS = skipIfLargerEventRecordedWithinMS {
+    if hasHigherTriggeredEvent(
+      activityName: activityName,
+      callbackName: callbackName,
+      eventName: eventName,
+      afterDate: Date.now
+        .addingTimeInterval(-skipIfLargerEventRecordedWithinMS).timeIntervalSince1970 * 1000
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
+
 // Optionally override any of the functions below.
 // Make sure that your class name matches the NSExtensionPrincipalClass in your Info.plist.
 @available(iOS 15.0, *)
@@ -19,19 +82,29 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     super.intervalDidStart(for: activity)
     logger.log("intervalDidStart")
 
+    self.executeActionsForEvent(
+      activityName: activity.rawValue,
+      callbackName: "intervalDidStart",
+      eventName: nil
+    )
+
     persistToUserDefaults(
       activityName: activity.rawValue,
       callbackName: "intervalDidStart"
     )
 
     notifyAppWithName(name: "intervalDidStart")
-
-    self.executeActionsForEvent(activityName: activity.rawValue, callbackName: "intervalDidStart")
   }
 
   override func intervalDidEnd(for activity: DeviceActivityName) {
     super.intervalDidEnd(for: activity)
     logger.log("intervalDidEnd")
+
+    self.executeActionsForEvent(
+      activityName: activity.rawValue,
+      callbackName: "intervalDidEnd",
+      eventName: nil
+    )
 
     persistToUserDefaults(
       activityName: activity.rawValue,
@@ -41,23 +114,45 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
 
     notifyAppWithName(name: "intervalDidEnd")
-
-    self.executeActionsForEvent(activityName: activity.rawValue, callbackName: "intervalDidEnd")
   }
 
-  func executeActionsForEvent(activityName: String, callbackName: String, eventName: String? = nil) {
+  func executeActionsForEvent(
+    activityName: String,
+    callbackName: String,
+    eventName: String?
+  ) {
     let key =
       eventName != nil
       ? "actions_for_\(activityName)_\(callbackName)_\(eventName!)"
       : "actions_for_\(activityName)_\(callbackName)"
 
     let placeholders = [
-      "activityName": activityName, "callbackName": callbackName, "eventName": eventName
+      "activityName": activityName,
+      "callbackName": callbackName,
+      "eventName": eventName
     ]
+
     if let actions = userDefaults?.array(forKey: key) {
       actions.forEach { actionRaw in
         if let action = actionRaw as? [String: Any] {
-          executeAction(action: action, placeholders: placeholders)
+          let skipIfAlreadyTriggeredAfter = action["skipIfAlreadyTriggeredAfter"] as? Double
+          let skipIfLargerEventRecordedAfter = action["skipIfLargerEventRecordedAfter"] as? Double
+          let skipIfAlreadyTriggeredWithinMS = action["skipIfAlreadyTriggeredWithinMS"] as? Double
+          let skipIfLargerEventRecordedWithinMS =
+            action["skipIfLargerEventRecordedWithinMS"] as? Double
+
+          if shouldExecuteAction(
+            skipIfAlreadyTriggeredAfter: skipIfAlreadyTriggeredAfter,
+            skipIfLargerEventRecordedAfter: skipIfLargerEventRecordedAfter,
+            skipIfAlreadyTriggeredWithinMS: skipIfAlreadyTriggeredWithinMS,
+            skipIfLargerEventRecordedWithinMS: skipIfLargerEventRecordedWithinMS,
+            activityName: activityName,
+            callbackName: callbackName,
+            eventName: eventName
+          ) {
+            executeAction(action: action, placeholders: placeholders)
+          }
+
         }
       }
     }
@@ -69,6 +164,12 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     super.eventDidReachThreshold(event, activity: activity)
     logger.log("eventDidReachThreshold: \(event.rawValue, privacy: .public)")
 
+    self.executeActionsForEvent(
+      activityName: activity.rawValue,
+      callbackName: "eventDidReachThreshold",
+      eventName: event.rawValue
+    )
+
     persistToUserDefaults(
       activityName: activity.rawValue,
       callbackName: "eventDidReachThreshold",
@@ -76,15 +177,17 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     )
 
     notifyAppWithName(name: "eventDidReachThreshold")
-
-    self.executeActionsForEvent(
-      activityName: activity.rawValue, callbackName: "eventDidReachThreshold",
-      eventName: event.rawValue)
   }
 
   override func intervalWillStartWarning(for activity: DeviceActivityName) {
     super.intervalWillStartWarning(for: activity)
     logger.log("intervalWillStartWarning")
+
+    self.executeActionsForEvent(
+      activityName: activity.rawValue,
+      callbackName: "intervalWillStartWarning",
+      eventName: nil
+    )
 
     persistToUserDefaults(
       activityName: activity.rawValue,
@@ -92,14 +195,17 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     )
 
     notifyAppWithName(name: "intervalWillStartWarning")
-
-    self.executeActionsForEvent(
-      activityName: activity.rawValue, callbackName: "intervalWillStartWarning")
   }
 
   override func intervalWillEndWarning(for activity: DeviceActivityName) {
     super.intervalWillEndWarning(for: activity)
     logger.log("intervalWillEndWarning")
+
+    self.executeActionsForEvent(
+      activityName: activity.rawValue,
+      callbackName: "intervalWillEndWarning",
+      eventName: nil
+    )
 
     persistToUserDefaults(
       activityName: activity.rawValue,
@@ -107,9 +213,6 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     )
 
     notifyAppWithName(name: "intervalWillEndWarning")
-
-    self.executeActionsForEvent(
-      activityName: activity.rawValue, callbackName: "intervalWillEndWarning")
   }
 
   override func eventWillReachThresholdWarning(
@@ -118,6 +221,12 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     super.eventWillReachThresholdWarning(event, activity: activity)
     logger.log("eventWillReachThresholdWarning: \(event.rawValue, privacy: .public)")
 
+    self.executeActionsForEvent(
+      activityName: activity.rawValue,
+      callbackName: "eventWillReachThresholdWarning",
+      eventName: event.rawValue
+    )
+
     persistToUserDefaults(
       activityName: activity.rawValue,
       callbackName: "eventWillReachThresholdWarning",
@@ -125,10 +234,6 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     )
 
     notifyAppWithName(name: "eventWillReachThresholdWarning")
-
-    self.executeActionsForEvent(
-      activityName: activity.rawValue, callbackName: "eventWillReachThresholdWarning",
-      eventName: event.rawValue)
   }
 
 }

--- a/targets/ShieldAction/ShieldActionExtension.swift
+++ b/targets/ShieldAction/ShieldActionExtension.swift
@@ -17,7 +17,7 @@ func handleAction(
   logger.log("handleAction")
   if let type = configForSelectedAction["type"] as? String {
     if type == "unblockAll" {
-      unblockAllApps()
+      unblockAllApps(triggeredBy: "shieldAction")
     }
 
     if type == "sendNotification" {

--- a/targets/ShieldAction/ShieldActionExtension.swift
+++ b/targets/ShieldAction/ShieldActionExtension.swift
@@ -74,7 +74,9 @@ func handleAction(
 ) {
   CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
 
-  if let shieldActionConfig = userDefaults?.dictionary(forKey: "shieldActions") {
+  if let shieldActionConfig = userDefaults?.dictionary(
+    forKey: SHIELD_ACTIONS_KEY
+  ) {
     if let configForSelectedAction = shieldActionConfig[
       action == .primaryButtonPressed ? "primary" : "secondary"] as? [String: Any] {
       let response = handleAction(

--- a/targets/ShieldConfiguration/ShieldConfigurationExtension.swift
+++ b/targets/ShieldConfiguration/ShieldConfigurationExtension.swift
@@ -63,7 +63,7 @@ func getShieldConfiguration(placeholders: [String: String?])
 
   CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
 
-  if let config = userDefaults?.dictionary(forKey: "shieldConfiguration") {
+  if let config = userDefaults?.dictionary(forKey: SHIELD_CONFIGURATION_KEY) {
     let backgroundColor = getColor(color: config["backgroundColor"] as? [String: Double])
 
     let title = config["title"] as? String


### PR DESCRIPTION
- Add multiple ways to skip event actions from triggering:
  - skipIfAlreadyTriggeredAfter?: Date; (good for initial setup but hard to use for follow-up days)
  - skipIfLargerEventRecordedAfter?: Date;
  - skipIfAlreadyTriggeredWithinMS?: number; (should be good for preventing "lower" events from triggering, for example a warning shield at 45 when 60 has already triggered)
  - skipIfLargerEventRecordedWithinMS?: number;
  - skipIfLargerEventRecordedSinceIntervalStarted?: boolean (since start of interval, for a daily monitor this resets at midnight)
  - neverTriggerBefore

Also adds more traceability:
- a lastBlock with triggeredBy (event name in most cases) and blockedAt and blockedFamilyActivitySelectionId
- a lastUnblock with triggeredBy and blockedAt
- together with the shieldConfiguration as well as shieldActions a triggeredBy and updatedAt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced device activity management with improved timing checks and condition-based execution of actions.
	- Added a reload capability for the activity center to instantly refresh displayed activity.
	- Expanded customization options for skipping actions based on specific timing criteria.
	- Introduced new test cases to verify action skipping functionality based on event triggers.
	- Added new constants for improved maintainability in user defaults handling.
	- Introduced a new `blockAppsWithSelectionId` method for enhanced app blocking functionality.

- **Bug Fixes**
	- Ensured consistent return types in event handling functions.

- **Chores**
	- Updated package version to v0.4.7 with underlying configuration and setup improvements.
	- Clarified project setup and configuration details in the contributing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->