### PR TITLE
No longer depend on relative location of node_modules

### DIFF
--- a/packages/react-native-device-activity/app.plugin.js
+++ b/packages/react-native-device-activity/app.plugin.js
@@ -6,7 +6,7 @@ const withCopyTargetFolder = require("./config-plugin/withCopyTargetFolder");
 const withEntitlementsPlugin = require("./config-plugin/withEntitlements");
 const withInfoPlistAppGroup = require("./config-plugin/withInfoPlistAppGroup");
 const withXcodeSettings = require("./config-plugin/withXCodeSettings");
-const pkg = require("../../package.json");
+const pkg = require(process.cwd() + "/package.json");
 
 /** @type {import('@expo/config-plugins').ConfigPlugin<{ appleTeamId?: string; match?: string; appGroup: string; copyToTargetFolder?: boolean }>} */
 const withActivityMonitorExtensionPlugin = (config, props) => {


### PR DESCRIPTION
This import fails in my pnpm monorepo because pnpm puts `node_modules` in a different place (with more nesting and symlinks etc). This small changes resolves it though.