### PR TITLE
fix: improve error handling in requestAuthorization

### DIFF
--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
@@ -547,7 +547,13 @@ public class ReactNativeDeviceActivityModule: Module {
         try await ac.requestAuthorization(
           for: forIndividualOrChild == "child" ? .child : .individual)
       } else {
-        logger.log("⚠️ iOS 16.0 or later is required to request authorization.")
+        let errorMessage = "iOS 16.0 or later is required to request authorization."
+        logger.log("⚠️ \(errorMessage)")
+        throw NSError(
+          domain: "FamilyControls",
+          code: 9999,
+          userInfo: [NSLocalizedDescriptionKey: errorMessage]
+        )
       }
     }
 

--- a/packages/react-native-device-activity/src/index.ts
+++ b/packages/react-native-device-activity/src/index.ts
@@ -39,8 +39,8 @@ export async function requestAuthorization(
       forIndividualOrChild,
     );
   } catch (error) {
-    // seems like we get a promise rejection if the user denies the authorization, but we can still request again
-    console.error(error);
+    // Re-throw the error so it can be properly handled by the caller
+    throw error;
   }
 }
 


### PR DESCRIPTION
Hi there!

Previously, `requestAuthorization` would silently catch and log errors, making it impossible for applications to handle authorization failures properly. This change allows callers to catch and handle errors appropriately, providing
  better user feedback.

- Re-throw errors from requestAuthorization instead of silently catching them
- Throw proper error for iOS < 16.0 instead of just logging
- Remove console.error to allow proper error handling by callers

This allows applications to properly handle authorization failures and provide appropriate user feedback.