### PR TITLE
fix: switch activity picker to native iOS sheet behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ For a complete implementation, see the [example app](https://github.com/Kingstin
 | Component                     | Props                                                                                                   | Description                                        |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | `DeviceActivitySelectionView` | `familyActivitySelection`: string \| null<br>`onSelectionChange`: (event) => void<br>`headerText?`: string<br>`footerText?`: string<br>`showNavigationBar?`: boolean<br>`onDismissRequest?`: (event) => void<br>`style`: ViewStyle | Native component that renders the app selection UI. Set `showNavigationBar` to use the native `.familyActivityPicker()` sheet with Cancel/Done. |
+| `DeviceActivitySelectionViewPersisted` | `familyActivitySelectionId`: string<br>`onSelectionChange`: (event) => void<br>`includeEntireCategory?`: boolean<br>`headerText?`: string<br>`footerText?`: string<br>`showNavigationBar?`: boolean<br>`onDismissRequest?`: (event) => void<br>`style`: ViewStyle | Persisted variant of the selection picker keyed by `familyActivitySelectionId`. Supports the same native sheet presentation with `showNavigationBar`. |
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -203,19 +203,18 @@ ReactNativeDeviceActivity.revokeAuthorization();
 
 For most use cases you need to get an activitySelection from the user, which is a token representing the apps the user wants to track, block or whitelist. This can be done by presenting the native `DeviceActivitySelectionView`.
 
-#### Presentation modes
+#### Presentation options
 
-The picker supports two presentation modes:
+The picker now has dedicated components for each presentation style:
 
-**Native sheet (recommended)** -- When you set `showNavigationBar={true}`, the native side uses Apple's `.familyActivityPicker(isPresented:selection:)` view modifier to present a fully native iOS sheet with Cancel/Done in the navigation bar. The native side handles the entire sheet presentation, so you do **not** need to wrap it in a React Native `<Modal>` -- just conditionally mount the view as a small anchor and it will present the sheet automatically.
+**Native sheet** -- `DeviceActivitySelectionSheetView` (and persisted variant) uses Apple's `.familyActivityPicker(isPresented:selection:)` flow with native Cancel/Done controls.
 
 ```TypeScript
-// The view acts as an invisible anchor — the native side presents its own sheet.
-// When the user taps Cancel or Done, onDismissRequest fires.
+// The sheet view acts as an invisible anchor.
+// The native side presents the iOS sheet and fires onDismissRequest on Cancel/Done.
 {pickerVisible && (
-  <DeviceActivitySelectionView
+  <DeviceActivitySelectionSheetView
     style={{ width: 1, height: 1, position: "absolute" }}
-    showNavigationBar
     onDismissRequest={() => setPickerVisible(false)}
     onSelectionChange={handleSelectionChange}
     familyActivitySelection={familyActivitySelection}
@@ -223,21 +222,26 @@ The picker supports two presentation modes:
 )}
 ```
 
-**Custom presentation (default)** -- Without `showNavigationBar`, the picker renders as an inline view with a large "Choose Activities" title. You can embed it directly in your layout or wrap it in a React Native `<Modal>` for a custom sheet. This gives you full control over the presentation but does not include native Cancel/Done buttons.
+**Custom presentation (fallback/customizable)** -- `DeviceActivitySelectionView` (and persisted variant) renders inline. You can embed it directly in your layout or wrap it in a React Native `<Modal>` for a custom sheet.
 
 ```TypeScript
 import { Modal, View } from "react-native";
 
-<Modal visible={visible} animationType="slide" presentationStyle="pageSheet"
-  onRequestClose={onDismiss} onDismiss={onDismiss}>
-  <View style={{ flex: 1 }}>
-    <DeviceActivitySelectionView
-      style={{ flex: 1, width: "100%" }}
-      onSelectionChange={handleSelectionChange}
-      familyActivitySelection={familyActivitySelection}
-    />
-  </View>
-</Modal>
+  <Modal
+    visible={visible}
+    animationType="slide"
+    presentationStyle="pageSheet"
+    onRequestClose={onDismiss}
+    onDismiss={onDismiss}
+  >
+    <View style={{ flex: 1 }}>
+      <DeviceActivitySelectionView
+        style={{ flex: 1, width: "100%" }}
+        onSelectionChange={handleSelectionChange}
+        familyActivitySelection={familyActivitySelection}
+      />
+    </View>
+  </Modal>
 ```
 
 #### Full example
@@ -589,8 +593,10 @@ For a complete implementation, see the [example app](https://github.com/Kingstin
 
 | Component                     | Props                                                                                                   | Description                                        |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `DeviceActivitySelectionView` | `familyActivitySelection`: string \| null<br>`onSelectionChange`: (event) => void<br>`headerText?`: string<br>`footerText?`: string<br>`showNavigationBar?`: boolean<br>`onDismissRequest?`: (event) => void<br>`style`: ViewStyle | Native component that renders the app selection UI. Set `showNavigationBar` to use the native `.familyActivityPicker()` sheet with Cancel/Done. |
-| `DeviceActivitySelectionViewPersisted` | `familyActivitySelectionId`: string<br>`onSelectionChange`: (event) => void<br>`includeEntireCategory?`: boolean<br>`headerText?`: string<br>`footerText?`: string<br>`showNavigationBar?`: boolean<br>`onDismissRequest?`: (event) => void<br>`style`: ViewStyle | Persisted variant of the selection picker keyed by `familyActivitySelectionId`. Supports the same native sheet presentation with `showNavigationBar`. |
+| `DeviceActivitySelectionView` | `familyActivitySelection`: string \| null<br>`onSelectionChange`: (event) => void<br>`headerText?`: string<br>`footerText?`: string<br>`style`: ViewStyle | Inline/customizable native picker view. Useful when you want to control modal/presentation yourself and provide a fallback UI. |
+| `DeviceActivitySelectionViewPersisted` | `familyActivitySelectionId`: string<br>`onSelectionChange`: (event) => void<br>`includeEntireCategory?`: boolean<br>`headerText?`: string<br>`footerText?`: string<br>`style`: ViewStyle | Persisted inline/customizable picker keyed by `familyActivitySelectionId`. |
+| `DeviceActivitySelectionSheetView` | `familyActivitySelection`: string \| null<br>`onSelectionChange`: (event) => void<br>`headerText?`: string<br>`footerText?`: string<br>`onDismissRequest?`: (event) => void<br>`style`: ViewStyle | Dedicated native iOS sheet picker with Cancel/Done controls. |
+| `DeviceActivitySelectionSheetViewPersisted` | `familyActivitySelectionId`: string<br>`onSelectionChange`: (event) => void<br>`includeEntireCategory?`: boolean<br>`headerText?`: string<br>`footerText?`: string<br>`onDismissRequest?`: (event) => void<br>`style`: ViewStyle | Persisted dedicated native iOS sheet picker keyed by `familyActivitySelectionId`. |
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ For most use cases you need to get an activitySelection from the user, which is 
 
 The picker now has dedicated components for each presentation style:
 
+`*SelectionView` components take a raw `familyActivitySelection` token.  
+`*SelectionViewPersisted` components take a `familyActivitySelectionId` and persist/read the token on the native side by ID.
+
 **Native sheet** -- `DeviceActivitySelectionSheetView` (and persisted variant) uses Apple's `.familyActivityPicker(isPresented:selection:)` flow with native Cancel/Done controls.
 
 ```TypeScript
@@ -227,22 +230,28 @@ The picker now has dedicated components for each presentation style:
 ```TypeScript
 import { Modal, View } from "react-native";
 
-  <Modal
-    visible={visible}
-    animationType="slide"
-    presentationStyle="pageSheet"
-    onRequestClose={onDismiss}
-    onDismiss={onDismiss}
-  >
-    <View style={{ flex: 1 }}>
-      <DeviceActivitySelectionView
-        style={{ flex: 1, width: "100%" }}
-        onSelectionChange={handleSelectionChange}
-        familyActivitySelection={familyActivitySelection}
-      />
-    </View>
-  </Modal>
+<Modal
+  visible={visible}
+  animationType="slide"
+  presentationStyle="pageSheet"
+  onRequestClose={onDismiss}
+  onDismiss={onDismiss}
+>
+  <View style={{ flex: 1 }}>
+    <DeviceActivitySelectionView
+      style={{ flex: 1, width: "100%" }}
+      onSelectionChange={handleSelectionChange}
+      familyActivitySelection={familyActivitySelection}
+    />
+  </View>
+</Modal>
 ```
+
+#### Which one should I use?
+
+- Use `DeviceActivitySelectionSheetView` for a native iOS sheet UX (system Cancel/Done).
+- Use `DeviceActivitySelectionView` when you need full control over presentation and a custom crash fallback UI.
+- Use the persisted variants when you want to store/reuse selections across screens/sessions or avoid passing very large selection tokens through JS.
 
 #### Full example
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,46 @@ ReactNativeDeviceActivity.revokeAuthorization();
 
 ### Select Apps to track
 
-For most use cases you need to get an activitySelection from the user, which is a token representing the apps the user wants to track, block or whitelist. This can be done by presenting the native view:
+For most use cases you need to get an activitySelection from the user, which is a token representing the apps the user wants to track, block or whitelist. This can be done by presenting the native `DeviceActivitySelectionView`.
+
+#### Presentation modes
+
+The picker supports two presentation modes:
+
+**Native sheet (recommended)** -- When you set `showNavigationBar={true}`, the native side uses Apple's `.familyActivityPicker(isPresented:selection:)` view modifier to present a fully native iOS sheet with Cancel/Done in the navigation bar. The native side handles the entire sheet presentation, so you do **not** need to wrap it in a React Native `<Modal>` -- just conditionally mount the view as a small anchor and it will present the sheet automatically.
+
+```TypeScript
+// The view acts as an invisible anchor — the native side presents its own sheet.
+// When the user taps Cancel or Done, onDismissRequest fires.
+{pickerVisible && (
+  <DeviceActivitySelectionView
+    style={{ width: 1, height: 1, position: "absolute" }}
+    showNavigationBar
+    onDismissRequest={() => setPickerVisible(false)}
+    onSelectionChange={handleSelectionChange}
+    familyActivitySelection={familyActivitySelection}
+  />
+)}
+```
+
+**Custom presentation (default)** -- Without `showNavigationBar`, the picker renders as an inline view with a large "Choose Activities" title. You can embed it directly in your layout or wrap it in a React Native `<Modal>` for a custom sheet. This gives you full control over the presentation but does not include native Cancel/Done buttons.
+
+```TypeScript
+import { Modal, View } from "react-native";
+
+<Modal visible={visible} animationType="slide" presentationStyle="pageSheet"
+  onRequestClose={onDismiss} onDismiss={onDismiss}>
+  <View style={{ flex: 1 }}>
+    <DeviceActivitySelectionView
+      style={{ flex: 1, width: "100%" }}
+      onSelectionChange={handleSelectionChange}
+      familyActivitySelection={familyActivitySelection}
+    />
+  </View>
+</Modal>
+```
+
+#### Full example
 
 ```TypeScript
 import * as ReactNativeDeviceActivity from "react-native-device-activity";
@@ -550,7 +589,7 @@ For a complete implementation, see the [example app](https://github.com/Kingstin
 
 | Component                     | Props                                                                                                   | Description                                        |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `DeviceActivitySelectionView` | `familyActivitySelection`: string \| null<br>`onSelectionChange`: (event) => void<br>`style`: ViewStyle | Native component that renders the app selection UI |
+| `DeviceActivitySelectionView` | `familyActivitySelection`: string \| null<br>`onSelectionChange`: (event) => void<br>`headerText?`: string<br>`footerText?`: string<br>`showNavigationBar?`: boolean<br>`onDismissRequest?`: (event) => void<br>`style`: ViewStyle | Native component that renders the app selection UI. Set `showNavigationBar` to use the native `.familyActivityPicker()` sheet with Cancel/Done. |
 
 ### Hooks
 

--- a/apps/example/components/ActivityPicker.tsx
+++ b/apps/example/components/ActivityPicker.tsx
@@ -1,4 +1,5 @@
-import { Pressable, Text, View, NativeSyntheticEvent } from "react-native";
+import React from "react";
+import { NativeSyntheticEvent, Pressable, StyleSheet, Text, View } from "react-native";
 import {
   ActivitySelectionMetadata,
   ActivitySelectionWithMetadata,
@@ -10,15 +11,7 @@ import { Modal, Portal } from "react-native-paper";
 const CrashView = ({ onReload }: { onReload: () => void }) => {
   return (
     <Pressable
-      style={{
-        flex: 1,
-        position: "absolute",
-        height: 600,
-        width: "100%",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: "white",
-      }}
+      style={styles.crashView}
       onPress={onReload}
     >
       <Text>Swift view crash - tap to reload</Text>
@@ -32,6 +25,7 @@ export const ActivityPicker = ({
   onSelectionChange,
   familyActivitySelection,
   onReload,
+  showNavigationBar = true,
 }: {
   visible: boolean;
   onDismiss: () => void;
@@ -40,35 +34,37 @@ export const ActivityPicker = ({
   ) => void;
   familyActivitySelection: string | undefined;
   onReload: () => void;
+  showNavigationBar?: boolean;
 }) => {
+  if (showNavigationBar) {
+    // Native presentation: the native side uses the
+    // .familyActivityPicker(isPresented:) modifier which presents its own
+    // sheet.  We just mount a tiny anchor view — no RN Modal needed.
+    if (!visible) return null;
+    return (
+      <DeviceActivitySelectionView
+        style={styles.nativeAnchor}
+        showNavigationBar
+        onDismissRequest={onDismiss}
+        onSelectionChange={onSelectionChange}
+        familyActivitySelection={familyActivitySelection}
+      />
+    );
+  }
+
+  // Custom modal: react-native-paper Portal + Modal with fixed height.
   return (
     <Portal>
       <Modal
         visible={visible}
         onDismiss={onDismiss}
-        contentContainerStyle={{
-          height: 600,
-        }}
+        contentContainerStyle={styles.modalContainer}
       >
-        <View
-          style={{
-            flex: 1,
-            height: 600,
-          }}
-        >
+        <View style={styles.modalContent}>
           <CrashView onReload={onReload} />
-
           {visible && (
             <DeviceActivitySelectionView
-              style={{
-                flex: 1,
-                height: 600,
-                width: "100%",
-                backgroundColor: "transparent",
-                pointerEvents: "none",
-              }}
-              headerText="a header text!"
-              footerText="a footer text!"
+              style={styles.picker}
               onSelectionChange={onSelectionChange}
               familyActivitySelection={familyActivitySelection}
             />
@@ -86,6 +82,7 @@ export const ActivityPickerPersisted = ({
   familyActivitySelectionId,
   onReload,
   includeEntireCategory,
+  showNavigationBar = true,
 }: {
   visible: boolean;
   onDismiss: () => void;
@@ -96,35 +93,34 @@ export const ActivityPickerPersisted = ({
   familyActivitySelectionId: string;
   onReload: () => void;
   includeEntireCategory?: boolean;
+  showNavigationBar?: boolean;
 }) => {
+  if (showNavigationBar) {
+    if (!visible) return null;
+    return (
+      <DeviceActivitySelectionViewPersisted
+        style={styles.nativeAnchor}
+        showNavigationBar
+        onDismissRequest={onDismiss}
+        onSelectionChange={onSelectionChange}
+        familyActivitySelectionId={familyActivitySelectionId}
+        includeEntireCategory={includeEntireCategory}
+      />
+    );
+  }
+
   return (
     <Portal>
       <Modal
         visible={visible}
         onDismiss={onDismiss}
-        contentContainerStyle={{
-          height: 600,
-        }}
+        contentContainerStyle={styles.modalContainer}
       >
-        <View
-          style={{
-            flex: 1,
-            height: 600,
-          }}
-        >
+        <View style={styles.modalContent}>
           <CrashView onReload={onReload} />
-
           {visible && (
             <DeviceActivitySelectionViewPersisted
-              style={{
-                flex: 1,
-                height: 600,
-                width: "100%",
-                backgroundColor: "transparent",
-                pointerEvents: "none",
-              }}
-              headerText="a header text!"
-              footerText="a footer text!"
+              style={styles.picker}
               onSelectionChange={onSelectionChange}
               familyActivitySelectionId={familyActivitySelectionId}
               includeEntireCategory={includeEntireCategory}
@@ -135,3 +131,34 @@ export const ActivityPickerPersisted = ({
     </Portal>
   );
 };
+
+const styles = StyleSheet.create({
+  // Invisible anchor for the native .familyActivityPicker() modifier.
+  nativeAnchor: {
+    width: 1,
+    height: 1,
+    position: "absolute",
+  },
+  modalContainer: {
+    height: 600,
+  },
+  modalContent: {
+    flex: 1,
+    height: 600,
+  },
+  crashView: {
+    flex: 1,
+    position: "absolute",
+    height: 600,
+    width: "100%",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "white",
+  },
+  picker: {
+    flex: 1,
+    height: 600,
+    width: "100%",
+    backgroundColor: "transparent",
+  },
+});

--- a/apps/example/components/ActivityPicker.tsx
+++ b/apps/example/components/ActivityPicker.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { NativeSyntheticEvent, Pressable, StyleSheet, Text, View } from "react-native";
 import {
   ActivitySelectionMetadata,
+  DeviceActivitySelectionSheetView,
+  DeviceActivitySelectionSheetViewPersisted,
   ActivitySelectionWithMetadata,
   DeviceActivitySelectionView,
   DeviceActivitySelectionViewPersisted,
@@ -42,9 +44,8 @@ export const ActivityPicker = ({
     // sheet.  We just mount a tiny anchor view — no RN Modal needed.
     if (!visible) return null;
     return (
-      <DeviceActivitySelectionView
+      <DeviceActivitySelectionSheetView
         style={styles.nativeAnchor}
-        showNavigationBar
         onDismissRequest={onDismiss}
         onSelectionChange={onSelectionChange}
         familyActivitySelection={familyActivitySelection}
@@ -98,9 +99,8 @@ export const ActivityPickerPersisted = ({
   if (showNavigationBar) {
     if (!visible) return null;
     return (
-      <DeviceActivitySelectionViewPersisted
+      <DeviceActivitySelectionSheetViewPersisted
         style={styles.nativeAnchor}
-        showNavigationBar
         onDismissRequest={onDismiss}
         onSelectionChange={onSelectionChange}
         familyActivitySelectionId={familyActivitySelectionId}

--- a/apps/example/components/CreateActivity.tsx
+++ b/apps/example/components/CreateActivity.tsx
@@ -1,12 +1,14 @@
 import { requestPermissionsAsync } from "expo-notifications";
 import { useCallback, useState } from "react";
-import { NativeSyntheticEvent, View } from "react-native";
+import { NativeSyntheticEvent, Pressable, View } from "react-native";
 import * as ReactNativeDeviceActivity from "react-native-device-activity";
 import {
   DeviceActivityEvent,
   DeviceActivitySelectionEvent,
 } from "react-native-device-activity/src/ReactNativeDeviceActivity.types";
 import { Button, Text, TextInput, Title, useTheme } from "react-native-paper";
+
+import { ActivityPicker } from "./ActivityPicker";
 
 const trackEveryXMinutes = 10;
 
@@ -175,6 +177,7 @@ export const CreateActivity = ({ onDismiss }: { onDismiss: () => void }) => {
   );
 
   const [activityName, setActivityName] = useState("");
+  const [showSelectionView, setShowSelectionView] = useState(false);
 
   return (
     <View style={{ margin: 20 }}>
@@ -187,33 +190,19 @@ export const CreateActivity = ({ onDismiss }: { onDismiss: () => void }) => {
           marginVertical: 10,
         }}
       >
-        <ReactNativeDeviceActivity.DeviceActivitySelectionView
+        <Pressable
           style={{
+            backgroundColor: theme.colors.primary,
             width: 100,
             height: 40,
             borderRadius: 20,
-            borderWidth: 10,
-            borderColor: theme.colors.primary,
+            alignItems: "center",
+            justifyContent: "center",
           }}
-          headerText="a header text!"
-          footerText="a footer text!"
-          onSelectionChange={onSelectionChange}
-          familyActivitySelection={
-            familyActivitySelectionResult?.familyActivitySelection
-          }
+          onPress={() => setShowSelectionView(true)}
         >
-          <View
-            pointerEvents="none"
-            style={{
-              backgroundColor: theme.colors.primary,
-              flex: 1,
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <Text style={{ color: "white" }}>Select apps</Text>
-          </View>
-        </ReactNativeDeviceActivity.DeviceActivitySelectionView>
+          <Text style={{ color: "white" }}>Select apps</Text>
+        </Pressable>
         <Text>
           {familyActivitySelectionResult &&
           familyActivitySelectionResult?.categoryCount < 13
@@ -223,6 +212,20 @@ export const CreateActivity = ({ onDismiss }: { onDismiss: () => void }) => {
               : "Nothing selected"}
         </Text>
       </View>
+      <ActivityPicker
+        visible={showSelectionView}
+        onDismiss={() => setShowSelectionView(false)}
+        onSelectionChange={onSelectionChange}
+        familyActivitySelection={
+          familyActivitySelectionResult?.familyActivitySelection ?? undefined
+        }
+        onReload={() => {
+          setShowSelectionView(false);
+          setTimeout(() => {
+            setShowSelectionView(true);
+          }, 100);
+        }}
+      />
       <TextInput
         placeholder="Enter activity name"
         onChangeText={(text) => setActivityName(text)}

--- a/apps/example/screens/SimpleTab.tsx
+++ b/apps/example/screens/SimpleTab.tsx
@@ -147,20 +147,20 @@ export function SimpleTab() {
           Create Activity
         </Button>
 
-        <Title style={{ marginTop: 20 }}>Picker Variants</Title>
+        <Title style={{ marginTop: 20 }}>Picker Views</Title>
         <Button
           mode="outlined"
           onPress={() => setPickerNative(true)}
           style={{ marginVertical: 4 }}
         >
-          Native Sheet
+          Sheet View (native iOS)
         </Button>
         <Button
           mode="outlined"
           onPress={() => setPickerCustomModal(true)}
           style={{ marginVertical: 4 }}
         >
-          Custom Modal (old default)
+          Selection View (custom wrapper)
         </Button>
       </ScrollView>
       <Modal
@@ -182,7 +182,7 @@ export function SimpleTab() {
         onSelectionChange={(
           event: NativeSyntheticEvent<ActivitySelectionMetadata>,
         ) => {
-          console.log("native sheet selection changed", event.nativeEvent);
+          console.log("sheet view selection changed", event.nativeEvent);
         }}
         familyActivitySelectionId="picker-native"
         onReload={() => {
@@ -197,7 +197,7 @@ export function SimpleTab() {
         onSelectionChange={(
           event: NativeSyntheticEvent<ActivitySelectionMetadata>,
         ) => {
-          console.log("custom modal selection changed", event.nativeEvent);
+          console.log("selection view changed", event.nativeEvent);
         }}
         familyActivitySelectionId="picker-custom-modal"
         onReload={() => {

--- a/apps/example/screens/SimpleTab.tsx
+++ b/apps/example/screens/SimpleTab.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import {
+  NativeSyntheticEvent,
   ScrollView,
   StyleSheet,
   Linking,
@@ -18,9 +19,11 @@ import {
   useAuthorizationStatus,
   AuthorizationStatusType,
   requestAuthorization,
+  ActivitySelectionMetadata,
 } from "react-native-device-activity";
 import { Button, Modal, Text, Title } from "react-native-paper";
 
+import { ActivityPickerPersisted } from "../components/ActivityPicker";
 import { CreateActivity } from "../components/CreateActivity";
 
 const authorizationStatusMap: Record<AuthorizationStatusType, string> = {
@@ -58,6 +61,9 @@ export function SimpleTab() {
   }, [authorizationStatus]);
 
   const [showCreateActivityPopup, setShowCreateActivityPopup] = useState(false);
+
+  const [pickerNative, setPickerNative] = useState(false);
+  const [pickerCustomModal, setPickerCustomModal] = useState(false);
 
   const [refreshing, setRefreshing] = useState(false);
 
@@ -140,6 +146,22 @@ export function SimpleTab() {
         >
           Create Activity
         </Button>
+
+        <Title style={{ marginTop: 20 }}>Picker Variants</Title>
+        <Button
+          mode="outlined"
+          onPress={() => setPickerNative(true)}
+          style={{ marginVertical: 4 }}
+        >
+          Native Sheet
+        </Button>
+        <Button
+          mode="outlined"
+          onPress={() => setPickerCustomModal(true)}
+          style={{ marginVertical: 4 }}
+        >
+          Custom Modal (old default)
+        </Button>
       </ScrollView>
       <Modal
         visible={showCreateActivityPopup}
@@ -153,6 +175,36 @@ export function SimpleTab() {
           }}
         />
       </Modal>
+      <ActivityPickerPersisted
+        visible={pickerNative}
+        onDismiss={() => setPickerNative(false)}
+        showNavigationBar
+        onSelectionChange={(
+          event: NativeSyntheticEvent<ActivitySelectionMetadata>,
+        ) => {
+          console.log("native sheet selection changed", event.nativeEvent);
+        }}
+        familyActivitySelectionId="picker-native"
+        onReload={() => {
+          setPickerNative(false);
+          setTimeout(() => setPickerNative(true), 100);
+        }}
+      />
+      <ActivityPickerPersisted
+        visible={pickerCustomModal}
+        onDismiss={() => setPickerCustomModal(false)}
+        showNavigationBar={false}
+        onSelectionChange={(
+          event: NativeSyntheticEvent<ActivitySelectionMetadata>,
+        ) => {
+          console.log("custom modal selection changed", event.nativeEvent);
+        }}
+        familyActivitySelectionId="picker-custom-modal"
+        onReload={() => {
+          setPickerCustomModal(false);
+          setTimeout(() => setPickerCustomModal(true), 100);
+        }}
+      />
     </SafeAreaView>
   );
 }

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
@@ -213,7 +213,8 @@ class NativeEventObserver {
           _: CFDictionary?
         ) in
         if let observer = observer, let name = name {
-          let nativeObserver = Unmanaged<NativeEventObserver>.fromOpaque(observer).takeUnretainedValue()
+          let nativeObserver = Unmanaged<NativeEventObserver>.fromOpaque(observer)
+            .takeUnretainedValue()
           guard let module = nativeObserver.module else {
             return
           }
@@ -828,7 +829,8 @@ public class ReactNativeDeviceActivityModule: Module {
     // view definition: Prop, Events.
     View(ReactNativeDeviceActivityView.self) {
       Events(
-        "onSelectionChange"
+        "onSelectionChange",
+        "onDismissRequest"
       )
       // Defines a setter for the `name` prop.
       Prop("familyActivitySelection") { (view: ReactNativeDeviceActivityView, prop: String) in
@@ -844,7 +846,12 @@ public class ReactNativeDeviceActivityModule: Module {
       Prop("headerText") { (view: ReactNativeDeviceActivityView, prop: String?) in
         view.model.headerText = prop
       }
+
+      Prop("showNavigationBar") { (view: ReactNativeDeviceActivityView, prop: Bool?) in
+        view.model.showNavigationBar = prop ?? false
+      }
     }
+
   }
 }
 
@@ -854,7 +861,8 @@ public class ReactNativeDeviceActivityViewPersistedModule: Module {
     Name("ReactNativeDeviceActivityViewPersistedModule")
     View(ReactNativeDeviceActivityViewPersisted.self) {
       Events(
-        "onSelectionChange"
+        "onSelectionChange",
+        "onDismissRequest"
       )
       // Defines a setter for the `name` prop.
       Prop("familyActivitySelectionId") {
@@ -893,6 +901,10 @@ public class ReactNativeDeviceActivityViewPersistedModule: Module {
 
       Prop("headerText") { (view: ReactNativeDeviceActivityViewPersisted, prop: String?) in
         view.model.headerText = prop
+      }
+
+      Prop("showNavigationBar") { (view: ReactNativeDeviceActivityViewPersisted, prop: Bool?) in
+        view.model.showNavigationBar = prop ?? false
       }
     }
   }

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
@@ -848,7 +848,13 @@ public class ReactNativeDeviceActivityModule: Module {
       }
 
       Prop("showNavigationBar") { (view: ReactNativeDeviceActivityView, prop: Bool?) in
-        view.model.showNavigationBar = prop ?? false
+        let enabled = prop ?? false
+        view.model.showNavigationBar = enabled
+        // When using the native .familyActivityPicker() modifier, set the
+        // hosting controller background so the presented sheet inherits it
+        // instead of falling through to the window's white default.
+        view.contentView.view.backgroundColor = enabled ? .systemGroupedBackground : .clear
+        view.backgroundColor = enabled ? .systemGroupedBackground : .clear
       }
     }
 
@@ -904,7 +910,10 @@ public class ReactNativeDeviceActivityViewPersistedModule: Module {
       }
 
       Prop("showNavigationBar") { (view: ReactNativeDeviceActivityViewPersisted, prop: Bool?) in
-        view.model.showNavigationBar = prop ?? false
+        let enabled = prop ?? false
+        view.model.showNavigationBar = enabled
+        view.contentView.view.backgroundColor = enabled ? .systemGroupedBackground : .clear
+        view.backgroundColor = enabled ? .systemGroupedBackground : .clear
       }
     }
   }

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityView.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityView.swift
@@ -24,8 +24,10 @@ class ReactNativeDeviceActivityView: ExpoView {
 
     clipsToBounds = true
     backgroundColor = .clear
+    isUserInteractionEnabled = false
 
     contentView.view.backgroundColor = .clear
+    contentView.view.isUserInteractionEnabled = false
 
     self.addSubview(contentView.view)
 

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityView.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityView.swift
@@ -24,12 +24,14 @@ class ReactNativeDeviceActivityView: ExpoView {
 
     clipsToBounds = true
     backgroundColor = .clear
-    isUserInteractionEnabled = false
 
     contentView.view.backgroundColor = .clear
-    contentView.view.isUserInteractionEnabled = false
 
     self.addSubview(contentView.view)
+
+    model.onDismissRequest = { [weak self] in
+      self?.onDismissRequest([:])
+    }
 
     model.$activitySelection.debounce(for: .seconds(0.1), scheduler: RunLoop.main).sink {
       selection in
@@ -45,7 +47,37 @@ class ReactNativeDeviceActivityView: ExpoView {
     contentView.view.frame = bounds
   }
 
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if window != nil {
+      // Establish a proper UIKit parent–child VC relationship so that
+      // SwiftUI presentation modifiers (like .familyActivityPicker) can
+      // walk the VC hierarchy and present sheets.
+      if contentView.parent == nil, let parentVC = parentViewController {
+        parentVC.addChild(contentView)
+        contentView.didMove(toParent: parentVC)
+      }
+    } else {
+      if contentView.parent != nil {
+        contentView.willMove(toParent: nil)
+        contentView.removeFromParent()
+      }
+    }
+  }
+
+  private var parentViewController: UIViewController? {
+    var responder: UIResponder? = self
+    while let next = responder?.next {
+      if let vc = next as? UIViewController {
+        return vc
+      }
+      responder = next
+    }
+    return nil
+  }
+
   let onSelectionChange = EventDispatcher()
+  let onDismissRequest = EventDispatcher()
 
   var previousSelection: FamilyActivitySelection?
 

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityViewPersisted.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityViewPersisted.swift
@@ -24,8 +24,10 @@ class ReactNativeDeviceActivityViewPersisted: ExpoView {
 
     clipsToBounds = true
     backgroundColor = .clear
+    isUserInteractionEnabled = false
 
     contentView.view.backgroundColor = .clear
+    contentView.view.isUserInteractionEnabled = false
 
     self.addSubview(contentView.view)
 

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityViewPersisted.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityViewPersisted.swift
@@ -24,12 +24,14 @@ class ReactNativeDeviceActivityViewPersisted: ExpoView {
 
     clipsToBounds = true
     backgroundColor = .clear
-    isUserInteractionEnabled = false
 
     contentView.view.backgroundColor = .clear
-    contentView.view.isUserInteractionEnabled = false
 
     self.addSubview(contentView.view)
+
+    model.onDismissRequest = { [weak self] in
+      self?.onDismissRequest([:])
+    }
 
     model.$activitySelection.debounce(for: .seconds(0.1), scheduler: RunLoop.main).sink {
       selection in
@@ -45,7 +47,34 @@ class ReactNativeDeviceActivityViewPersisted: ExpoView {
     contentView.view.frame = bounds
   }
 
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if window != nil {
+      if contentView.parent == nil, let parentVC = parentViewController {
+        parentVC.addChild(contentView)
+        contentView.didMove(toParent: parentVC)
+      }
+    } else {
+      if contentView.parent != nil {
+        contentView.willMove(toParent: nil)
+        contentView.removeFromParent()
+      }
+    }
+  }
+
+  private var parentViewController: UIViewController? {
+    var responder: UIResponder? = self
+    while let next = responder?.next {
+      if let vc = next as? UIViewController {
+        return vc
+      }
+      responder = next
+    }
+    return nil
+  }
+
   let onSelectionChange = EventDispatcher()
+  let onDismissRequest = EventDispatcher()
 
   var previousSelection: FamilyActivitySelection?
 

--- a/packages/react-native-device-activity/src/DeviceActivitySelectionSheetView.ios.tsx
+++ b/packages/react-native-device-activity/src/DeviceActivitySelectionSheetView.ios.tsx
@@ -1,0 +1,21 @@
+import { requireNativeViewManager } from "expo-modules-core";
+import * as React from "react";
+
+import {
+  DeviceActivitySelectionSheetViewProps,
+  DeviceActivitySelectionViewProps,
+} from "./ReactNativeDeviceActivity.types";
+
+type NativeSheetViewProps = DeviceActivitySelectionViewProps & {
+  showNavigationBar: boolean;
+  onDismissRequest?: DeviceActivitySelectionSheetViewProps["onDismissRequest"];
+};
+
+const NativeView: React.ComponentType<NativeSheetViewProps> =
+  requireNativeViewManager("ReactNativeDeviceActivity");
+
+export default function DeviceActivitySelectionSheetView(
+  props: DeviceActivitySelectionSheetViewProps,
+) {
+  return <NativeView {...props} showNavigationBar />;
+}

--- a/packages/react-native-device-activity/src/DeviceActivitySelectionSheetView.tsx
+++ b/packages/react-native-device-activity/src/DeviceActivitySelectionSheetView.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { View } from "react-native";
+
+import { DeviceActivitySelectionSheetViewProps } from "./ReactNativeDeviceActivity.types";
+
+export default function DeviceActivitySelectionSheetView({
+  style,
+  children,
+}: DeviceActivitySelectionSheetViewProps) {
+  return <View style={style}>{children}</View>;
+}

--- a/packages/react-native-device-activity/src/DeviceActivitySelectionSheetViewPersisted.ios.tsx
+++ b/packages/react-native-device-activity/src/DeviceActivitySelectionSheetViewPersisted.ios.tsx
@@ -1,0 +1,22 @@
+import { requireNativeViewManager } from "expo-modules-core";
+import * as React from "react";
+
+import {
+  DeviceActivitySelectionSheetViewPersistedProps,
+  DeviceActivitySelectionViewPersistedProps,
+} from "./ReactNativeDeviceActivity.types";
+
+type NativeSheetViewPersistedProps = DeviceActivitySelectionViewPersistedProps & {
+  showNavigationBar: boolean;
+  onDismissRequest?:
+    DeviceActivitySelectionSheetViewPersistedProps["onDismissRequest"];
+};
+
+const NativeView: React.ComponentType<NativeSheetViewPersistedProps> =
+  requireNativeViewManager("ReactNativeDeviceActivityViewPersistedModule");
+
+export default function DeviceActivitySelectionSheetViewPersisted(
+  props: DeviceActivitySelectionSheetViewPersistedProps,
+) {
+  return <NativeView {...props} showNavigationBar />;
+}

--- a/packages/react-native-device-activity/src/DeviceActivitySelectionSheetViewPersisted.tsx
+++ b/packages/react-native-device-activity/src/DeviceActivitySelectionSheetViewPersisted.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { View } from "react-native";
+
+import { DeviceActivitySelectionSheetViewPersistedProps } from "./ReactNativeDeviceActivity.types";
+
+export default function DeviceActivitySelectionSheetViewPersisted({
+  style,
+  children,
+}: DeviceActivitySelectionSheetViewPersistedProps) {
+  return <View style={style}>{children}</View>;
+}

--- a/packages/react-native-device-activity/src/ReactNativeDeviceActivity.types.ts
+++ b/packages/react-native-device-activity/src/ReactNativeDeviceActivity.types.ts
@@ -44,6 +44,17 @@ export type DeviceActivitySelectionViewProps = PropsWithChildren<{
   familyActivitySelection?: string | null;
   headerText?: string | null;
   footerText?: string | null;
+  /**
+   * When true, wraps the picker in a NavigationView with Cancel/Done toolbar
+   * buttons, matching the native `.familyActivityPicker()` presentation style.
+   * Use together with `onDismissRequest` to handle dismissal.
+   */
+  showNavigationBar?: boolean;
+  /**
+   * Called when the user taps Cancel or Done in the navigation bar.
+   * Only fires when `showNavigationBar` is true.
+   */
+  onDismissRequest?: (event: NativeSyntheticEvent<Record<string, never>>) => void;
 }>;
 
 export type DeviceActivitySelectionViewPersistedProps = PropsWithChildren<{
@@ -59,6 +70,17 @@ export type DeviceActivitySelectionViewPersistedProps = PropsWithChildren<{
    * @link https://developer.apple.com/documentation/familycontrols/familyactivityselection/includeentirecategory
    */
   includeEntireCategory?: boolean;
+  /**
+   * When true, wraps the picker in a NavigationView with Cancel/Done toolbar
+   * buttons, matching the native `.familyActivityPicker()` presentation style.
+   * Use together with `onDismissRequest` to handle dismissal.
+   */
+  showNavigationBar?: boolean;
+  /**
+   * Called when the user taps Cancel or Done in the navigation bar.
+   * Only fires when `showNavigationBar` is true.
+   */
+  onDismissRequest?: (event: NativeSyntheticEvent<Record<string, never>>) => void;
 }>;
 
 /**

--- a/packages/react-native-device-activity/src/ReactNativeDeviceActivity.types.ts
+++ b/packages/react-native-device-activity/src/ReactNativeDeviceActivity.types.ts
@@ -44,18 +44,14 @@ export type DeviceActivitySelectionViewProps = PropsWithChildren<{
   familyActivitySelection?: string | null;
   headerText?: string | null;
   footerText?: string | null;
+}>;
+
+export type DeviceActivitySelectionSheetViewProps = DeviceActivitySelectionViewProps & {
   /**
-   * When true, wraps the picker in a NavigationView with Cancel/Done toolbar
-   * buttons, matching the native `.familyActivityPicker()` presentation style.
-   * Use together with `onDismissRequest` to handle dismissal.
-   */
-  showNavigationBar?: boolean;
-  /**
-   * Called when the user taps Cancel or Done in the navigation bar.
-   * Only fires when `showNavigationBar` is true.
+   * Called when the user taps Cancel or Done in the native sheet navigation bar.
    */
   onDismissRequest?: (event: NativeSyntheticEvent<Record<string, never>>) => void;
-}>;
+};
 
 export type DeviceActivitySelectionViewPersistedProps = PropsWithChildren<{
   style?: StyleProp<ViewStyle>;
@@ -70,18 +66,15 @@ export type DeviceActivitySelectionViewPersistedProps = PropsWithChildren<{
    * @link https://developer.apple.com/documentation/familycontrols/familyactivityselection/includeentirecategory
    */
   includeEntireCategory?: boolean;
-  /**
-   * When true, wraps the picker in a NavigationView with Cancel/Done toolbar
-   * buttons, matching the native `.familyActivityPicker()` presentation style.
-   * Use together with `onDismissRequest` to handle dismissal.
-   */
-  showNavigationBar?: boolean;
-  /**
-   * Called when the user taps Cancel or Done in the navigation bar.
-   * Only fires when `showNavigationBar` is true.
-   */
-  onDismissRequest?: (event: NativeSyntheticEvent<Record<string, never>>) => void;
 }>;
+
+export type DeviceActivitySelectionSheetViewPersistedProps =
+  DeviceActivitySelectionViewPersistedProps & {
+    /**
+     * Called when the user taps Cancel or Done in the native sheet navigation bar.
+     */
+    onDismissRequest?: (event: NativeSyntheticEvent<Record<string, never>>) => void;
+  };
 
 /**
  * @link https://developer.apple.com/documentation/foundation/datecomponents

--- a/packages/react-native-device-activity/src/index.test.ts
+++ b/packages/react-native-device-activity/src/index.test.ts
@@ -1,6 +1,14 @@
 // todo: skipping for now
 
 describe("test", () => {
+  test("Should export sheet picker views", () => {
+    jest.isolateModules(() => {
+      const module = require("./");
+      expect(module.DeviceActivitySelectionSheetView).toBeDefined();
+      expect(module.DeviceActivitySelectionSheetViewPersisted).toBeDefined();
+    });
+  });
+
   test("Should call stopMonitoring", () => {
     const mockStopMonitoring = jest.fn();
     jest.mock("./ReactNativeDeviceActivityModule", () => ({

--- a/packages/react-native-device-activity/src/index.ts
+++ b/packages/react-native-device-activity/src/index.ts
@@ -2,6 +2,8 @@ import { EventEmitter, EventSubscription } from "expo-modules-core";
 import { useCallback, useEffect, useState } from "react";
 import { Platform } from "react-native";
 
+import DeviceActivitySelectionSheetView from "./DeviceActivitySelectionSheetView";
+import DeviceActivitySelectionSheetViewPersisted from "./DeviceActivitySelectionSheetViewPersisted";
 import DeviceActivitySelectionView from "./DeviceActivitySelectionView";
 import DeviceActivitySelectionViewPersisted from "./DeviceActivitySelectionViewPersisted";
 import {
@@ -18,6 +20,8 @@ import {
   DeviceActivityEventRaw,
   DeviceActivityMonitorEventPayload,
   DeviceActivitySchedule,
+  DeviceActivitySelectionSheetViewPersistedProps,
+  DeviceActivitySelectionSheetViewProps,
   DeviceActivitySelectionViewPersistedProps,
   DeviceActivitySelectionViewProps,
   EventListenerMap,
@@ -649,9 +653,16 @@ export function isAvailable(): boolean {
   );
 }
 
-export { DeviceActivitySelectionView, DeviceActivitySelectionViewPersisted };
+export {
+  DeviceActivitySelectionSheetView,
+  DeviceActivitySelectionSheetViewPersisted,
+  DeviceActivitySelectionView,
+  DeviceActivitySelectionViewPersisted,
+};
 
 export type {
+  DeviceActivitySelectionSheetViewProps as ReactNativeDeviceActivitySheetViewProps,
+  DeviceActivitySelectionSheetViewPersistedProps as ReactNativeDeviceActivitySheetViewPersistedProps,
   DeviceActivitySelectionViewProps as ReactNativeDeviceActivityViewProps,
   DeviceActivitySelectionViewPersistedProps as ReactNativeDeviceActivityViewPersistedProps,
 };


### PR DESCRIPTION
This PR updates picker presentation by introducing dedicated sheet components while keeping the existing customizable selection view path.

Main changes:
- Keep existing customizable/fallback views:
  - `DeviceActivitySelectionView`
  - `DeviceActivitySelectionViewPersisted`
- Add dedicated native sheet views:
  - `DeviceActivitySelectionSheetView`
  - `DeviceActivitySelectionSheetViewPersisted`
- Keep iOS native sheet internals (`.familyActivityPicker(isPresented:)`, Cancel/Done, parent/child VC wiring) behind the new sheet components.
- Fix sheet bottom background to `systemGroupedBackground` so the presented sheet matches system visuals.
- Update example app to expose both implementations clearly:
  - Sheet View (native iOS)
  - Selection View (custom wrapper)
- Fix a **pre-existing example bug** where tapping “Select apps” inside Create Activity did not open picker flow.
- Clarify README docs around:
  - sheet vs selection view choice
  - persisted vs non-persisted variants

## Why

The native sheet UX is better for standard iOS behavior, but the customizable selection view path is still useful for custom presentation and fallback handling.  
This keeps both paths first-class and explicit.

## API impact

No breaking changes.

Added components:
- `DeviceActivitySelectionSheetView`
- `DeviceActivitySelectionSheetViewPersisted`

Notes:
- `DeviceActivitySelectionView*` remain the customizable inline/custom-wrapper components.
- `onDismissRequest` is available on the new sheet components.

## Screenshots

| Selection View (custom wrapper) | Sheet View (native iOS) |
| --- | --- |
| ![old](https://github.com/user-attachments/assets/76318d66-6fb2-4d03-babc-bf9a2d9f70e3) | ![new](https://github.com/user-attachments/assets/fb14525d-9e9f-42f5-8267-f47f84e0976c) |

| Updated example app UI |
| --- |
| <img src="https://github.com/user-attachments/assets/0228d29b-df5a-4ad6-8f29-f9be7342de92" width="300" /> |

## Validation

- Ran `bun run pre-push` (typecheck/lint/SwiftLint strict).
- Manually verified:
  - sheet view opens native iOS Cancel/Done flow
  - dismiss callback fires correctly
  - sheet background fix is applied
  - selection view custom-wrapper path still works
  - Create Activity “Select apps” now opens picker flow
  - example “Picker Views” labels reflect actual component model