### PR TITLE
feat: add DeviceActivityLabelListView

### DIFF
--- a/packages/react-native-device-activity/expo-module.config.json
+++ b/packages/react-native-device-activity/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "platforms": ["ios"],
   "ios": {
-    "modules": ["ReactNativeDeviceActivityModule", "ReactNativeDeviceActivityViewPersistedModule"]
+    "modules": ["ReactNativeDeviceActivityModule", "ReactNativeDeviceActivityViewPersistedModule", "ReactNativeDeviceActivityLabelListModule"]
   }
 }

--- a/packages/react-native-device-activity/ios/ActivityLabelList.swift
+++ b/packages/react-native-device-activity/ios/ActivityLabelList.swift
@@ -14,7 +14,7 @@ class ActivityLabelListModel: ObservableObject {
   @Published var activitySelection = FamilyActivitySelection()
 }
 
-@available(iOS 15.0, *)
+@available(iOS 15.2, *)
 struct ActivityLabelList: View {
   @ObservedObject var model: ActivityLabelListModel
 

--- a/packages/react-native-device-activity/ios/ActivityLabelList.swift
+++ b/packages/react-native-device-activity/ios/ActivityLabelList.swift
@@ -1,0 +1,35 @@
+//
+//  ActivityLabelList.swift
+//  ReactNativeDeviceActivity
+//
+
+import Combine
+import ExpoModulesCore
+import FamilyControls
+import Foundation
+import SwiftUI
+
+@available(iOS 15.0, *)
+class ActivityLabelListModel: ObservableObject {
+  @Published var activitySelection = FamilyActivitySelection()
+}
+
+@available(iOS 15.0, *)
+struct ActivityLabelList: View {
+  @ObservedObject var model: ActivityLabelListModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      ForEach(Array(model.activitySelection.applicationTokens), id: \.self) { token in
+        Label(token)
+          .padding(.vertical, 8)
+          .padding(.horizontal, 12)
+      }
+      ForEach(Array(model.activitySelection.categoryTokens), id: \.self) { token in
+        Label(token)
+          .padding(.vertical, 8)
+          .padding(.horizontal, 12)
+      }
+    }
+  }
+}

--- a/packages/react-native-device-activity/ios/ActivityLabelList.swift
+++ b/packages/react-native-device-activity/ios/ActivityLabelList.swift
@@ -12,6 +12,30 @@ import SwiftUI
 @available(iOS 15.0, *)
 class ActivityLabelListModel: ObservableObject {
   @Published var activitySelection = FamilyActivitySelection()
+  var familyActivitySelectionId: String?
+  private var cancellable: AnyCancellable?
+
+  func startObserving() {
+    cancellable = NotificationCenter.default
+      .publisher(for: UserDefaults.didChangeNotification)
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] _ in
+        self?.refreshSelection()
+      }
+  }
+
+  func refreshSelection() {
+    guard let id = familyActivitySelectionId else { return }
+    if let selection = getFamilyActivitySelectionById(id: id) {
+      activitySelection = selection
+    } else {
+      activitySelection = FamilyActivitySelection()
+    }
+  }
+
+  deinit {
+    cancellable?.cancel()
+  }
 }
 
 @available(iOS 15.0, *)

--- a/packages/react-native-device-activity/ios/ActivityLabelList.swift
+++ b/packages/react-native-device-activity/ios/ActivityLabelList.swift
@@ -14,21 +14,23 @@ class ActivityLabelListModel: ObservableObject {
   @Published var activitySelection = FamilyActivitySelection()
 }
 
-@available(iOS 15.2, *)
+@available(iOS 15.0, *)
 struct ActivityLabelList: View {
   @ObservedObject var model: ActivityLabelListModel
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      ForEach(Array(model.activitySelection.applicationTokens), id: \.self) { token in
-        Label(token)
-          .padding(.vertical, 8)
-          .padding(.horizontal, 12)
-      }
-      ForEach(Array(model.activitySelection.categoryTokens), id: \.self) { token in
-        Label(token)
-          .padding(.vertical, 8)
-          .padding(.horizontal, 12)
+      if #available(iOS 15.2, *) {
+        ForEach(Array(model.activitySelection.applicationTokens), id: \.self) { token in
+          Label(token)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+        }
+        ForEach(Array(model.activitySelection.categoryTokens), id: \.self) { token in
+          Label(token)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+        }
       }
     }
   }

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityLabelListView.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityLabelListView.swift
@@ -3,7 +3,7 @@ import FamilyControls
 import SwiftUI
 import UIKit
 
-@available(iOS 15.2, *)
+@available(iOS 15.0, *)
 class ReactNativeDeviceActivityLabelListView: ExpoView {
 
   let model = ActivityLabelListModel()

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityLabelListView.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityLabelListView.swift
@@ -10,6 +10,10 @@ class ReactNativeDeviceActivityLabelListView: ExpoView {
 
   let contentView: UIHostingController<ActivityLabelList>
 
+  let onContentSizeChange = EventDispatcher()
+
+  private var lastReportedHeight: CGFloat = 0
+
   required init(appContext: AppContext? = nil) {
     contentView = UIHostingController(
       rootView: ActivityLabelList(model: model)
@@ -17,7 +21,7 @@ class ReactNativeDeviceActivityLabelListView: ExpoView {
 
     super.init(appContext: appContext)
 
-    clipsToBounds = true
+    clipsToBounds = false
     backgroundColor = .clear
 
     contentView.view.backgroundColor = .clear
@@ -27,27 +31,20 @@ class ReactNativeDeviceActivityLabelListView: ExpoView {
 
   override func layoutSubviews() {
     super.layoutSubviews()
-    contentView.view.frame = bounds
 
-    // Report intrinsic size so RN can size this view to fit content
-    let fittingSize = contentView.view.systemLayoutSizeFitting(
-      CGSize(width: bounds.width, height: UIView.layoutFittingCompressedSize.height),
-      withHorizontalFittingPriority: .required,
-      verticalFittingPriority: .fittingSizeLevel
+    let targetWidth = bounds.width > 0 ? bounds.width : UIView.layoutFittingExpandedSize.width
+    let fittingSize = contentView.view.sizeThatFits(
+      CGSize(width: targetWidth, height: .greatestFiniteMagnitude)
     )
-    if abs(fittingSize.height - bounds.height) > 1.0 && fittingSize.height > 0 {
-      invalidateIntrinsicContentSize()
+
+    contentView.view.frame = CGRect(
+      origin: .zero,
+      size: CGSize(width: bounds.width, height: fittingSize.height)
+    )
+
+    if fittingSize.height > 0 && abs(fittingSize.height - lastReportedHeight) > 0.5 {
+      lastReportedHeight = fittingSize.height
+      onContentSizeChange(["height": fittingSize.height])
     }
-  }
-
-  override var intrinsicContentSize: CGSize {
-    let fittingSize = contentView.view.systemLayoutSizeFitting(
-      CGSize(
-        width: bounds.width > 0 ? bounds.width : UIView.layoutFittingExpandedSize.width,
-        height: UIView.layoutFittingCompressedSize.height),
-      withHorizontalFittingPriority: .required,
-      verticalFittingPriority: .fittingSizeLevel
-    )
-    return fittingSize
   }
 }

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityLabelListView.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityLabelListView.swift
@@ -1,0 +1,53 @@
+import ExpoModulesCore
+import FamilyControls
+import SwiftUI
+import UIKit
+
+@available(iOS 15.0, *)
+class ReactNativeDeviceActivityLabelListView: ExpoView {
+
+  let model = ActivityLabelListModel()
+
+  let contentView: UIHostingController<ActivityLabelList>
+
+  required init(appContext: AppContext? = nil) {
+    contentView = UIHostingController(
+      rootView: ActivityLabelList(model: model)
+    )
+
+    super.init(appContext: appContext)
+
+    clipsToBounds = true
+    backgroundColor = .clear
+
+    contentView.view.backgroundColor = .clear
+
+    self.addSubview(contentView.view)
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    contentView.view.frame = bounds
+
+    // Report intrinsic size so RN can size this view to fit content
+    let fittingSize = contentView.view.systemLayoutSizeFitting(
+      CGSize(width: bounds.width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    if abs(fittingSize.height - bounds.height) > 1.0 && fittingSize.height > 0 {
+      invalidateIntrinsicContentSize()
+    }
+  }
+
+  override var intrinsicContentSize: CGSize {
+    let fittingSize = contentView.view.systemLayoutSizeFitting(
+      CGSize(
+        width: bounds.width > 0 ? bounds.width : UIView.layoutFittingExpandedSize.width,
+        height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return fittingSize
+  }
+}

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityLabelListView.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityLabelListView.swift
@@ -3,7 +3,7 @@ import FamilyControls
 import SwiftUI
 import UIKit
 
-@available(iOS 15.0, *)
+@available(iOS 15.2, *)
 class ReactNativeDeviceActivityLabelListView: ExpoView {
 
   let model = ActivityLabelListModel()

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
@@ -947,7 +947,7 @@ public class ReactNativeDeviceActivityViewPersistedModule: Module {
   }
 }
 
-@available(iOS 15.2, *)
+@available(iOS 15.0, *)
 public class ReactNativeDeviceActivityLabelListModule: Module {
   public func definition() -> ExpoModulesCore.ModuleDefinition {
     Name("ReactNativeDeviceActivityLabelListModule")

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
@@ -133,7 +133,8 @@ struct DeviceActivityEventFromJS: ExpoModulesCore.Record {
   var includesPastActivity: Bool?
 }
 
-func convertToSwiftDateComponents(from dateComponentsFromJS: DateComponentsFromJS) -> DateComponents {
+func convertToSwiftDateComponents(from dateComponentsFromJS: DateComponentsFromJS) -> DateComponents
+{
   var swiftDateComponents = DateComponents()
 
   if let era = dateComponentsFromJS.era {
@@ -571,13 +572,16 @@ public class ReactNativeDeviceActivityModule: Module {
           for: forIndividualOrChild == "child" ? .child : .individual)
       } else {
         // Deprecated iOS 15 API - uses completion handler
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        try await withCheckedThrowingContinuation {
+          (continuation: CheckedContinuation<Void, Error>) in
           ac.requestAuthorization { result in
             switch result {
             case .success:
               continuation.resume()
             case .failure(let error):
-              logger.log("❌ Failed to request authorization: \(error.localizedDescription, privacy: .public)")
+              logger.log(
+                "❌ Failed to request authorization: \(error.localizedDescription, privacy: .public)"
+              )
               continuation.resume(throwing: error)
             }
           }
@@ -939,6 +943,23 @@ public class ReactNativeDeviceActivityViewPersistedModule: Module {
         view.model.showNavigationBar = enabled
         view.contentView.view.backgroundColor = enabled ? .systemGroupedBackground : .clear
         view.backgroundColor = enabled ? .systemGroupedBackground : .clear
+      }
+    }
+  }
+}
+
+@available(iOS 15.0, *)
+public class ReactNativeDeviceActivityLabelListModule: Module {
+  public func definition() -> ExpoModulesCore.ModuleDefinition {
+    Name("ReactNativeDeviceActivityLabelListModule")
+    View(ReactNativeDeviceActivityLabelListView.self) {
+      Prop("familyActivitySelectionId") {
+        (view: ReactNativeDeviceActivityLabelListView, prop: String) in
+        if let selection = getFamilyActivitySelectionById(id: prop) {
+          view.model.activitySelection = selection
+        } else {
+          view.model.activitySelection = FamilyActivitySelection()
+        }
       }
     }
   }

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
@@ -133,8 +133,7 @@ struct DeviceActivityEventFromJS: ExpoModulesCore.Record {
   var includesPastActivity: Bool?
 }
 
-func convertToSwiftDateComponents(from dateComponentsFromJS: DateComponentsFromJS) -> DateComponents
-{
+func convertToSwiftDateComponents(from dateComponentsFromJS: DateComponentsFromJS) -> DateComponents {
   var swiftDateComponents = DateComponents()
 
   if let era = dateComponentsFromJS.era {
@@ -948,7 +947,7 @@ public class ReactNativeDeviceActivityViewPersistedModule: Module {
   }
 }
 
-@available(iOS 15.0, *)
+@available(iOS 15.2, *)
 public class ReactNativeDeviceActivityLabelListModule: Module {
   public func definition() -> ExpoModulesCore.ModuleDefinition {
     Name("ReactNativeDeviceActivityLabelListModule")

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
@@ -952,6 +952,8 @@ public class ReactNativeDeviceActivityLabelListModule: Module {
   public func definition() -> ExpoModulesCore.ModuleDefinition {
     Name("ReactNativeDeviceActivityLabelListModule")
     View(ReactNativeDeviceActivityLabelListView.self) {
+      Events("onContentSizeChange")
+
       Prop("familyActivitySelectionId") {
         (view: ReactNativeDeviceActivityLabelListView, prop: String) in
         view.model.familyActivitySelectionId = prop

--- a/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
+++ b/packages/react-native-device-activity/ios/ReactNativeDeviceActivityModule.swift
@@ -954,11 +954,9 @@ public class ReactNativeDeviceActivityLabelListModule: Module {
     View(ReactNativeDeviceActivityLabelListView.self) {
       Prop("familyActivitySelectionId") {
         (view: ReactNativeDeviceActivityLabelListView, prop: String) in
-        if let selection = getFamilyActivitySelectionById(id: prop) {
-          view.model.activitySelection = selection
-        } else {
-          view.model.activitySelection = FamilyActivitySelection()
-        }
+        view.model.familyActivitySelectionId = prop
+        view.model.refreshSelection()
+        view.model.startObserving()
       }
     }
   }

--- a/packages/react-native-device-activity/src/DeviceActivityLabelListView.ios.tsx
+++ b/packages/react-native-device-activity/src/DeviceActivityLabelListView.ios.tsx
@@ -1,0 +1,13 @@
+import { requireNativeViewManager } from "expo-modules-core";
+import * as React from "react";
+
+import { DeviceActivityLabelListViewProps } from "./ReactNativeDeviceActivity.types";
+
+const NativeView: React.ComponentType<DeviceActivityLabelListViewProps> =
+	requireNativeViewManager("ReactNativeDeviceActivityLabelListModule");
+
+export default function DeviceActivityLabelListView(
+	props: DeviceActivityLabelListViewProps,
+) {
+	return <NativeView {...props} />;
+}

--- a/packages/react-native-device-activity/src/DeviceActivityLabelListView.ios.tsx
+++ b/packages/react-native-device-activity/src/DeviceActivityLabelListView.ios.tsx
@@ -1,13 +1,29 @@
 import { requireNativeViewManager } from "expo-modules-core";
 import * as React from "react";
+import { NativeSyntheticEvent } from "react-native";
 
 import { DeviceActivityLabelListViewProps } from "./ReactNativeDeviceActivity.types";
 
-const NativeView: React.ComponentType<DeviceActivityLabelListViewProps> =
-	requireNativeViewManager("ReactNativeDeviceActivityLabelListModule");
+type NativeProps = DeviceActivityLabelListViewProps & {
+	onContentSizeChange?: (
+		event: NativeSyntheticEvent<{ height: number }>,
+	) => void;
+};
+
+const NativeView: React.ComponentType<NativeProps> = requireNativeViewManager(
+	"ReactNativeDeviceActivityLabelListModule",
+);
 
 export default function DeviceActivityLabelListView(
 	props: DeviceActivityLabelListViewProps,
 ) {
-	return <NativeView {...props} />;
+	const [height, setHeight] = React.useState(0);
+
+	return (
+		<NativeView
+			{...props}
+			style={[props.style, height > 0 && { height }]}
+			onContentSizeChange={(e) => setHeight(e.nativeEvent.height)}
+		/>
+	);
 }

--- a/packages/react-native-device-activity/src/DeviceActivityLabelListView.tsx
+++ b/packages/react-native-device-activity/src/DeviceActivityLabelListView.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { View } from "react-native";
+
+import { DeviceActivityLabelListViewProps } from "./ReactNativeDeviceActivity.types";
+
+export default function DeviceActivityLabelListView({
+	style,
+	children,
+}: DeviceActivityLabelListViewProps) {
+	return <View style={style}>{children}</View>;
+}

--- a/packages/react-native-device-activity/src/ReactNativeDeviceActivity.types.ts
+++ b/packages/react-native-device-activity/src/ReactNativeDeviceActivity.types.ts
@@ -76,6 +76,11 @@ export type DeviceActivitySelectionSheetViewPersistedProps =
     onDismissRequest?: (event: NativeSyntheticEvent<Record<string, never>>) => void;
   };
 
+export type DeviceActivityLabelListViewProps = PropsWithChildren<{
+  style?: StyleProp<ViewStyle>;
+  familyActivitySelectionId: string;
+}>;
+
 /**
  * @link https://developer.apple.com/documentation/foundation/datecomponents
  */

--- a/packages/react-native-device-activity/src/index.ts
+++ b/packages/react-native-device-activity/src/index.ts
@@ -680,6 +680,8 @@ export function isAvailable(): boolean {
   );
 }
 
+export { default as DeviceActivityLabelListView } from "./DeviceActivityLabelListView";
+
 export {
   DeviceActivitySelectionSheetView,
   DeviceActivitySelectionSheetViewPersisted,

--- a/packages/react-native-device-activity/targets/ShieldAction/ShieldActionExtension.swift
+++ b/packages/react-native-device-activity/targets/ShieldAction/ShieldActionExtension.swift
@@ -164,48 +164,6 @@ func handleShieldAction(
   return .close
 }
 
-// MARK: - App name persistence
-// Writes app/category/domain display names to shared UserDefaults so the main
-// app can read them. Names are only available in extension contexts.
-
-func stableTokenKey<T: Encodable>(for token: T) -> String? {
-  guard let data = try? JSONEncoder().encode(token) else { return nil }
-  return data.base64EncodedString()
-}
-
-func persistAppName(_ name: String?, forToken token: ApplicationToken?) {
-  guard let name = name, let token = token,
-    let key = stableTokenKey(for: token)
-  else { return }
-  var dict = userDefaults?.dictionary(forKey: "guardedAppNames") as? [String: String] ?? [:]
-  dict[key] = name
-  userDefaults?.set(dict, forKey: "guardedAppNames")
-  userDefaults?.synchronize()
-  logger.log("Persisted app name '\(name, privacy: .public)'")
-}
-
-func persistCategoryName(_ name: String?, forToken token: ActivityCategoryToken?) {
-  guard let name = name, let token = token,
-    let key = stableTokenKey(for: token)
-  else { return }
-  var dict = userDefaults?.dictionary(forKey: "guardedCategoryNames") as? [String: String] ?? [:]
-  dict[key] = name
-  userDefaults?.set(dict, forKey: "guardedCategoryNames")
-  userDefaults?.synchronize()
-  logger.log("Persisted category name '\(name, privacy: .public)'")
-}
-
-func persistWebDomainName(_ domain: String?, forToken token: WebDomainToken?) {
-  guard let domain = domain, let token = token,
-    let key = stableTokenKey(for: token)
-  else { return }
-  var dict = userDefaults?.dictionary(forKey: "guardedWebDomainNames") as? [String: String] ?? [:]
-  dict[key] = domain
-  userDefaults?.set(dict, forKey: "guardedWebDomainNames")
-  userDefaults?.synchronize()
-  logger.log("Persisted web domain '\(domain, privacy: .public)'")
-}
-
 func handleAction(
   action: ShieldAction,
   completionHandler: @escaping (ShieldActionResponse) -> Void,
@@ -214,19 +172,6 @@ func handleAction(
   categoryToken: ActivityCategoryToken?
 ) {
   CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
-
-  // Persist display names to shared UserDefaults for the main app
-  if let applicationToken = applicationToken {
-    persistAppName(
-      Application(token: applicationToken).localizedDisplayName, forToken: applicationToken)
-  }
-  if let webdomainToken = webdomainToken {
-    persistWebDomainName(WebDomain(token: webdomainToken).domain, forToken: webdomainToken)
-  }
-  if let categoryToken = categoryToken {
-    persistCategoryName(
-      ActivityCategory(token: categoryToken).localizedDisplayName, forToken: categoryToken)
-  }
 
   if let shieldActionConfig = getActivitySelectionPrefixedConfigFromUserDefaults(
     keyPrefix: SHIELD_ACTIONS_FOR_SELECTION_PREFIX,
@@ -252,7 +197,7 @@ func handleAction(
           ? WebDomain(
             token: webdomainToken!
           ).domain : nil,
-        "familyActivitySelectionId": familyActivitySelectionId?.id,
+        "familyActivitySelectionId": familyActivitySelectionId?.id
       ]
 
       let response = handleShieldAction(

--- a/packages/react-native-device-activity/targets/ShieldAction/ShieldActionExtension.swift
+++ b/packages/react-native-device-activity/targets/ShieldAction/ShieldActionExtension.swift
@@ -164,6 +164,48 @@ func handleShieldAction(
   return .close
 }
 
+// MARK: - App name persistence
+// Writes app/category/domain display names to shared UserDefaults so the main
+// app can read them. Names are only available in extension contexts.
+
+func stableTokenKey<T: Encodable>(for token: T) -> String? {
+  guard let data = try? JSONEncoder().encode(token) else { return nil }
+  return data.base64EncodedString()
+}
+
+func persistAppName(_ name: String?, forToken token: ApplicationToken?) {
+  guard let name = name, let token = token,
+    let key = stableTokenKey(for: token)
+  else { return }
+  var dict = userDefaults?.dictionary(forKey: "guardedAppNames") as? [String: String] ?? [:]
+  dict[key] = name
+  userDefaults?.set(dict, forKey: "guardedAppNames")
+  userDefaults?.synchronize()
+  logger.log("Persisted app name '\(name, privacy: .public)'")
+}
+
+func persistCategoryName(_ name: String?, forToken token: ActivityCategoryToken?) {
+  guard let name = name, let token = token,
+    let key = stableTokenKey(for: token)
+  else { return }
+  var dict = userDefaults?.dictionary(forKey: "guardedCategoryNames") as? [String: String] ?? [:]
+  dict[key] = name
+  userDefaults?.set(dict, forKey: "guardedCategoryNames")
+  userDefaults?.synchronize()
+  logger.log("Persisted category name '\(name, privacy: .public)'")
+}
+
+func persistWebDomainName(_ domain: String?, forToken token: WebDomainToken?) {
+  guard let domain = domain, let token = token,
+    let key = stableTokenKey(for: token)
+  else { return }
+  var dict = userDefaults?.dictionary(forKey: "guardedWebDomainNames") as? [String: String] ?? [:]
+  dict[key] = domain
+  userDefaults?.set(dict, forKey: "guardedWebDomainNames")
+  userDefaults?.synchronize()
+  logger.log("Persisted web domain '\(domain, privacy: .public)'")
+}
+
 func handleAction(
   action: ShieldAction,
   completionHandler: @escaping (ShieldActionResponse) -> Void,
@@ -172,6 +214,19 @@ func handleAction(
   categoryToken: ActivityCategoryToken?
 ) {
   CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
+
+  // Persist display names to shared UserDefaults for the main app
+  if let applicationToken = applicationToken {
+    persistAppName(
+      Application(token: applicationToken).localizedDisplayName, forToken: applicationToken)
+  }
+  if let webdomainToken = webdomainToken {
+    persistWebDomainName(WebDomain(token: webdomainToken).domain, forToken: webdomainToken)
+  }
+  if let categoryToken = categoryToken {
+    persistCategoryName(
+      ActivityCategory(token: categoryToken).localizedDisplayName, forToken: categoryToken)
+  }
 
   if let shieldActionConfig = getActivitySelectionPrefixedConfigFromUserDefaults(
     keyPrefix: SHIELD_ACTIONS_FOR_SELECTION_PREFIX,
@@ -197,7 +252,7 @@ func handleAction(
           ? WebDomain(
             token: webdomainToken!
           ).domain : nil,
-        "familyActivitySelectionId": familyActivitySelectionId?.id
+        "familyActivitySelectionId": familyActivitySelectionId?.id,
       ]
 
       let response = handleShieldAction(


### PR DESCRIPTION
## Summary
- Adds a new `DeviceActivityLabelListView` native component that renders Apple's `Label(token)` for each selected app/category from a persisted `FamilyActivitySelection`
- Self-sizing: the native view measures its content and reports height to JS via `onContentSizeChange` event
- Auto-refreshing: observes `UserDefaults.didChangeNotification` to re-read the selection when it changes
- Exports TypeScript component with `.ios.tsx` (native) and `.tsx` (fallback) variants

## New files
- `ActivityLabelList.swift` — SwiftUI view with `Label(token)` rendering
- `ReactNativeDeviceActivityLabelListView.swift` — ExpoView wrapper with content size reporting
- `DeviceActivityLabelListView.ios.tsx` / `.tsx` — JS components

## Test plan
- [x] TypeScript compiles (`bun run typecheck`)
- [x] ESLint passes (`bun run lint`)
- [x] SwiftLint passes (0 violations)
- [ ] Verified on real device: app labels render, list auto-sizes, updates on selection change